### PR TITLE
More closures - 1

### DIFF
--- a/src/org/nut/dynamatrix/Dynamatrix.groovy
+++ b/src/org/nut/dynamatrix/Dynamatrix.groovy
@@ -265,10 +265,11 @@ class Dynamatrix implements Cloneable {
                 txt = this.toStringStageCount()
             }
             txt = "Build in progress: " + txt
-            this.script.addInfoBadge(text: txt, id: "Build-progress@" + this.objectID)
+            // Note: not "addInfoBadge()" which is rolled-up and small (no text except when hovered)
+            this.script.addBadge(icon: 'info.gif', text: txt, id: "Build-progress@" + this.objectID)
             return true
         } catch (Throwable t) {
-            this.script.echo "WARNING: Tried to removeBadges() and addInfoBadge() for Build-progress, but failed to; are the Groovy Postbuild plugin and jenkins-badge-plugin installed?"
+            this.script.echo "WARNING: Tried to addBadge() for 'Build-progress@${this.objectID}', but failed to; are the Groovy Postbuild plugin and jenkins-badge-plugin installed?"
             if (this.shouldDebugTrace()) {
                 this.script.echo (t.toString())
             }

--- a/src/org/nut/dynamatrix/Dynamatrix.groovy
+++ b/src/org/nut/dynamatrix/Dynamatrix.groovy
@@ -1613,9 +1613,9 @@ def parallelStages = prepareDynamatrix(
                                     "Message: " + hexA.getMessage() +
                                     "; Cause: " + hexA.getCause() +
                                     "; toString: " + hexA.toString();
-                                dsbc.thisDynamatrix?.countStagesIncrement(hexAres, stageName + sbName) // for debug
                                 dsbc.thisDynamatrix?.countStagesIncrement('FAILURE', stageName + sbName) // could be unstable, learn how to differentiate?
                                 if (dsbc.enableDebugTrace) {
+                                    dsbc.thisDynamatrix?.countStagesIncrement('DEBUG-EXC-FAILURE: ' + hexAres, stageName + sbName) // for debug
                                     StringWriter errors = new StringWriter();
                                     hexA.printStackTrace(new PrintWriter(errors));
                                     script.echo (
@@ -1650,9 +1650,9 @@ def parallelStages = prepareDynamatrix(
                                     "Message: " + rae.getMessage() +
                                     "; Cause: " + rae.getCause() +
                                     "; toString: " + rae.toString();
-                                dsbc.thisDynamatrix?.countStagesIncrement(raeRes, stageName + sbName) // for debug
                                 dsbc.thisDynamatrix?.countStagesIncrement('UNKNOWN', stageName + sbName) // FAILURE technically, but one we could not classify exactly
                                 if (dsbc.enableDebugTrace) {
+                                    dsbc.thisDynamatrix?.countStagesIncrement('DEBUG-EXC-UNKNOWN: ' + raeRes, stageName + sbName) // for debug
                                     StringWriter errors = new StringWriter();
                                     rae.printStackTrace(new PrintWriter(errors));
                                     script.echo (

--- a/src/org/nut/dynamatrix/Dynamatrix.groovy
+++ b/src/org/nut/dynamatrix/Dynamatrix.groovy
@@ -243,38 +243,64 @@ class Dynamatrix implements Cloneable {
             return null
 
         try {
-            try {
-                this.script.removeBadges(id: "Build-progress@" + this.objectID)
-            } catch (Throwable tOK) { // ok if missing
-                this.script.echo "WARNING: Tried to removeBadges() for 'Build-progress@${this.objectID}', but failed to; are the Groovy Postbuild plugin and jenkins-badge-plugin installed?"
-                if (this.shouldDebugTrace()) {
-                    this.script.echo (t.toString())
-                }
-            }
-            if (removeOnly) return true
-
-            // Stage finished, update the rolling progress via GPBP steps (with id)
-            def txt = this.toStringStageCountNonZero()
-            if (!(Utils.isStringNotEmpty(txt))) {
-                txt = this.toStringStageCountDumpNonZero()
-            }
-            if (!(Utils.isStringNotEmpty(txt))) {
-                txt = this.toStringStageCountDump()
-            }
-            if (!(Utils.isStringNotEmpty(txt))) {
-                txt = this.toStringStageCount()
-            }
-            txt = "Build in progress: " + txt
-            // Note: not "addInfoBadge()" which is rolled-up and small (no text except when hovered)
-            this.script.addBadge(icon: 'info.gif', text: txt, id: "Build-progress@" + this.objectID)
-            return true
-        } catch (Throwable t) {
-            this.script.echo "WARNING: Tried to addBadge() for 'Build-progress@${this.objectID}', but failed to; are the Groovy Postbuild plugin and jenkins-badge-plugin installed?"
+            this.script.removeBadges(id: "Build-progress-badge@" + this.objectID)
+        } catch (Throwable tOK) { // ok if missing
+            this.script.echo "WARNING: Tried to removeBadges() for 'Build-progress-badge@${this.objectID}', but failed to; are the Groovy Postbuild plugin and jenkins-badge-plugin installed?"
             if (this.shouldDebugTrace()) {
                 this.script.echo (t.toString())
             }
-            return false
         }
+
+        try {
+            this.script.removeBadges(id: "Build-progress-summary@" + this.objectID)
+        } catch (Throwable tOK) { // ok if missing
+            this.script.echo "WARNING: Tried to removeBadges() for 'Build-progress-summary@${this.objectID}', but failed to; are the Groovy Postbuild plugin and jenkins-badge-plugin installed?"
+            if (this.shouldDebugTrace()) {
+                this.script.echo (t.toString())
+            }
+        }
+        if (removeOnly) return true
+
+        // Stage finished, update the rolling progress via GPBP steps (with id)
+        def txt = this.toStringStageCountNonZero()
+        if (!(Utils.isStringNotEmpty(txt))) {
+            txt = this.toStringStageCountDumpNonZero()
+        }
+        if (!(Utils.isStringNotEmpty(txt))) {
+            txt = this.toStringStageCountDump()
+        }
+        if (!(Utils.isStringNotEmpty(txt))) {
+            txt = this.toStringStageCount()
+        }
+        txt = "Build in progress: " + txt
+
+        def res = null
+        try {
+            // Note: not "addInfoBadge()" which is rolled-up and small (no text except when hovered)
+            // Update: although this seems to have same effect, not that of addShortText (that has no "id")
+            this.script.addBadge(icon: 'info.gif', text: txt, id: "Build-progress-badge@" + this.objectID)
+            res = true
+        } catch (Throwable t) {
+            this.script.echo "WARNING: Tried to addBadge() for 'Build-progress-badge@${this.objectID}', but failed to; are the Groovy Postbuild plugin and jenkins-badge-plugin installed?"
+            if (this.shouldDebugTrace()) {
+                this.script.echo (t.toString())
+            }
+            res = false
+        }
+
+        try {
+            // Roll a text entry in the build overview page
+            this.script.createSummary(icon: 'info.gif', text: txt, id: "Build-progress-summary@" + this.objectID)
+            if (res == null) res = true
+        } catch (Throwable t) {
+            this.script.echo "WARNING: Tried to createSummary() for 'Build-progress-badge@${this.objectID}', but failed to; are the Groovy Postbuild plugin and jenkins-badge-plugin installed?"
+            if (this.shouldDebugTrace()) {
+                this.script.echo (t.toString())
+            }
+            res = false
+        }
+
+        return res
     }
 
 ////////////////////////// END OF RESULTS ACCOUNTING ///////////////////

--- a/src/org/nut/dynamatrix/Dynamatrix.groovy
+++ b/src/org/nut/dynamatrix/Dynamatrix.groovy
@@ -145,11 +145,16 @@ class Dynamatrix implements Cloneable {
     synchronized public String getLogKey(String s) {
         // Return either direct hit, or startsWith (where the tail
         // would be description of the slowBuild scenario group)
-        def k = trackStageLogkeys?.s
-        if (k) return k
-        k = trackStageLogkeys.any { sn, lk ->
-            if (sn?.startsWith(s))
-                return lk
+        if (trackStageLogkeys.containsKey(s)) {
+            return trackStageLogkeys[s]
+        }
+
+        def k = null
+        trackStageLogkeys.each { sn, lk ->
+            if (sn?.startsWith(s)) {
+                k = lk
+                return true
+            }
             return false // continue the search
         }
         return k // may be null if no hit

--- a/src/org/nut/dynamatrix/Dynamatrix.groovy
+++ b/src/org/nut/dynamatrix/Dynamatrix.groovy
@@ -278,7 +278,8 @@ class Dynamatrix implements Cloneable {
         try {
             // Note: not "addInfoBadge()" which is rolled-up and small (no text except when hovered)
             // Update: although this seems to have same effect, not that of addShortText (that has no "id")
-            this.script.addBadge(icon: 'info.gif', text: txt, id: "Build-progress-badge@" + this.objectID)
+            // Update2: checking with a "null" icon if that would work as addShortText in effect (seems so by build.xml markup)
+            this.script.addBadge(icon: null, text: txt, id: "Build-progress-badge@" + this.objectID)
             res = true
         } catch (Throwable t) {
             this.script.echo "WARNING: Tried to addBadge() for 'Build-progress-badge@${this.objectID}', but failed to; are the Groovy Postbuild plugin and jenkins-badge-plugin installed?"

--- a/src/org/nut/dynamatrix/Dynamatrix.groovy
+++ b/src/org/nut/dynamatrix/Dynamatrix.groovy
@@ -1215,11 +1215,11 @@ def parallelStages = prepareDynamatrix(
                         buildResult: 'SUCCESS', stageResult: 'FAILURE'
                     ) {
                         script.withEnv(['CI_ALLOWED_FAILURE=true']) {
-                            return generatedBuildWrapperLayer2(stageName, dsbc, body)//CLS//.call()
+                            generatedBuildWrapperLayer2(stageName, dsbc, body)//CLS//.call()
                         }
                     } // catchError
                 } else {
-                    return generatedBuildWrapperLayer2(stageName, dsbc, body)//CLS//.call()
+                    generatedBuildWrapperLayer2(stageName, dsbc, body)//CLS//.call()
                 } // if allowedFailure
 //            } // stage
 //CLS//

--- a/src/org/nut/dynamatrix/Dynamatrix.groovy
+++ b/src/org/nut/dynamatrix/Dynamatrix.groovy
@@ -1129,7 +1129,8 @@ def parallelStages = prepareDynamatrix(
         def debugTrace = this.shouldDebugTrace()
 
         // echo's below are not debug-decorated, in these cases they are the payload
-//CLS//        return {
+//CLS//
+        return {
             script.withEnv(dsbc.getKVSet().sort()) { // by side effect, sorting turns the Set into an array
 //SCR//                script.script {
 
@@ -1185,7 +1186,8 @@ def parallelStages = prepareDynamatrix(
 
 //SCR//                } // script
             } // withEnv
-//CLS//        } // return a Closure
+//CLS//
+        } // return a Closure
 
     }
 
@@ -1198,7 +1200,8 @@ def parallelStages = prepareDynamatrix(
          * the string around.
          */
 
-//CLS//        return {
+//CLS//
+        return {
 //            script.stage(stageName) {
                 if (dsbc.enableDebugTrace) script.echo "Running stage: ${stageName}" + "\n  for ${Utils.castString(dsbc)}"
                 if (dsbc.isAllowedFailure) {
@@ -1207,14 +1210,15 @@ def parallelStages = prepareDynamatrix(
                         buildResult: 'SUCCESS', stageResult: 'FAILURE'
                     ) {
                         script.withEnv(['CI_ALLOWED_FAILURE=true']) {
-                            generatedBuildWrapperLayer2(stageName, dsbc, body)//CLS//.call()
+                            return generatedBuildWrapperLayer2(stageName, dsbc, body)//CLS//.call()
                         }
                     } // catchError
                 } else {
-                    generatedBuildWrapperLayer2(stageName, dsbc, body)//CLS//.call()
+                    return generatedBuildWrapperLayer2(stageName, dsbc, body)//CLS//.call()
                 } // if allowedFailure
 //            } // stage
-//CLS//        } // return a Closure
+//CLS//
+        } // return a Closure
 
     }
 
@@ -1341,9 +1345,9 @@ def parallelStages = prepareDynamatrix(
             }
 
             // Named closure to call below
-            def payload = {
+            def payload = //NONCLS//{
                 generatedBuildWrapperLayer1(stageName, dsbc, body)//CLS//.call()
-            }
+            //NONCLS//}
 
             // Pattern for code change on the fly:
             if (matrixTag != null) {

--- a/src/org/nut/dynamatrix/Dynamatrix.groovy
+++ b/src/org/nut/dynamatrix/Dynamatrix.groovy
@@ -178,7 +178,9 @@ class Dynamatrix implements Cloneable {
 
         def k = null
         trackStageLogkeys.each { sn, lk ->
-            if (sn?.startsWith(s)) {
+            if (Utils.isStringNotEmpty(sn)
+            &&  (sn.startsWith(s) || s.startsWith(sn))
+            ) {
                 k = lk
                 return true
             }

--- a/src/org/nut/dynamatrix/Dynamatrix.groovy
+++ b/src/org/nut/dynamatrix/Dynamatrix.groovy
@@ -130,7 +130,7 @@ class Dynamatrix implements Cloneable {
                     // a sub-set or super-set of the "sn". We want to keep
                     // the longer version to help troubleshooting.
                     def trackedSN = null
-                    this.trackStageResults.each { tsk ->
+                    this.trackStageResults.each { tsk, tsr ->
                         if (tsk.startsWith(sn) || sn.startsWith(tsk)) {
                             trackedSN = tsk
                             return true

--- a/src/org/nut/dynamatrix/Dynamatrix.groovy
+++ b/src/org/nut/dynamatrix/Dynamatrix.groovy
@@ -147,8 +147,8 @@ class Dynamatrix implements Cloneable {
     }
 
     @NonCPS
-    synchronized public Integer countStagesIncrement(Result r) {
-        return this.countStagesIncrement(r?.toString())
+    synchronized public Integer countStagesIncrement(Result r, String sn = null) {
+        return this.countStagesIncrement(r?.toString(), sn)
     }
 
     @NonCPS

--- a/src/org/nut/dynamatrix/Dynamatrix.groovy
+++ b/src/org/nut/dynamatrix/Dynamatrix.groovy
@@ -78,6 +78,8 @@ class Dynamatrix implements Cloneable {
         ]
     // For each stageName, track its Result object (if set by stage payload)
     private Map<String, Result> trackStageResults = [:]
+    // Plaintext or shortened-hash names of log files and other data saved for stage
+    private Map<String, String> trackStageLogkeys = [:]
 
     @NonCPS
     public static Result resultFromString(String k) {
@@ -132,6 +134,25 @@ class Dynamatrix implements Cloneable {
         }
 
         return res
+    }
+
+    @NonCPS
+    synchronized public void setLogKey(String sn, String lk) {
+        trackStageLogkeys[sn] = lk
+    }
+
+    @NonCPS
+    synchronized public String getLogKey(String s) {
+        // Return either direct hit, or startsWith (where the tail
+        // would be description of the slowBuild scenario group)
+        def k = trackStageLogkeys?.s
+        if (k) return k
+        k = trackStageLogkeys.any { sn, lk ->
+            if (sn?.startsWith(s))
+                return lk
+            return false // continue the search
+        }
+        return k // may be null if no hit
     }
 
     @NonCPS

--- a/src/org/nut/dynamatrix/Dynamatrix.groovy
+++ b/src/org/nut/dynamatrix/Dynamatrix.groovy
@@ -1217,15 +1217,15 @@ def parallelStages = prepareDynamatrix(
                         script.withEnv(['CI_ALLOWED_FAILURE=true']) {
                             def payloadLayer2 = dsbc.thisDynamatrix.
                                 generatedBuildWrapperLayer2(stageName, dsbc, body)//CLS//.call()
-                            //return payloadLayer2()
-                            return payloadLayer2
+                            return payloadLayer2()
+                            //return payloadLayer2
                         }
                     } // catchError
                 } else {
                     def payloadLayer2 = dsbc.thisDynamatrix.
                         generatedBuildWrapperLayer2(stageName, dsbc, body)//CLS//.call()
-                    //return payloadLayer2()
-                    return payloadLayer2
+                    return payloadLayer2()
+                    //return payloadLayer2
                 } // if allowedFailure
 //            } // stage
 //CLS//

--- a/src/org/nut/dynamatrix/Dynamatrix.groovy
+++ b/src/org/nut/dynamatrix/Dynamatrix.groovy
@@ -1128,6 +1128,10 @@ def parallelStages = prepareDynamatrix(
          */
         def debugTrace = this.shouldDebugTrace()
 
+        // For delegation to closure and beyond
+        script = this.script
+        body.delegate.script = this.script
+
         // echo's below are not debug-decorated, in these cases they are the payload
 //CLS//
         return { ->
@@ -1171,7 +1175,8 @@ def parallelStages = prepareDynamatrix(
                         //     setDelegate(delegate)
                         //     echo "${stageName} ==> ${dsbc.clioptSet.toString()}"
                         // }
-                        body(body.delegate)
+                        //NONCLS?// body(body.delegate)
+                        body.call(body.delegate)
 /*
                         // Alas, this does not work to simplify the pipeline
                         // side of code:
@@ -1326,6 +1331,10 @@ def parallelStages = prepareDynamatrix(
                 def bodyData = [ dsbc: dsbc.clone(), stageName: sn ]
                 body = bodyOrig.clone().rehydrate(bodyData, this.script, body)
                 body.resolveStrategy = Closure.DELEGATE_FIRST
+                if (!Utils.isMapNotEmpty(body.delegate))
+                    body.delegate = [:]
+                body.delegate.dsbc = dsbc
+                body.delegate.stageName = stageName
             }
 
             String matrixTag = null

--- a/src/org/nut/dynamatrix/Dynamatrix.groovy
+++ b/src/org/nut/dynamatrix/Dynamatrix.groovy
@@ -1215,11 +1215,17 @@ def parallelStages = prepareDynamatrix(
                         buildResult: 'SUCCESS', stageResult: 'FAILURE'
                     ) {
                         script.withEnv(['CI_ALLOWED_FAILURE=true']) {
-                            generatedBuildWrapperLayer2(stageName, dsbc, body)//CLS//.call()
+                            def payloadLayer2 = dsbc.thisDynamatrix.
+                                generatedBuildWrapperLayer2(stageName, dsbc, body)//CLS//.call()
+                            //return payloadLayer2()
+                            return payloadLayer2
                         }
                     } // catchError
                 } else {
-                    generatedBuildWrapperLayer2(stageName, dsbc, body)//CLS//.call()
+                    def payloadLayer2 = dsbc.thisDynamatrix.
+                        generatedBuildWrapperLayer2(stageName, dsbc, body)//CLS//.call()
+                    //return payloadLayer2()
+                    return payloadLayer2
                 } // if allowedFailure
 //            } // stage
 //CLS//

--- a/src/org/nut/dynamatrix/Dynamatrix.groovy
+++ b/src/org/nut/dynamatrix/Dynamatrix.groovy
@@ -1130,7 +1130,7 @@ def parallelStages = prepareDynamatrix(
 
         // echo's below are not debug-decorated, in these cases they are the payload
 //CLS//
-        return {
+        return { ->
             script.withEnv(dsbc.getKVSet().sort()) { // by side effect, sorting turns the Set into an array
 //SCR//                script.script {
 
@@ -1201,7 +1201,7 @@ def parallelStages = prepareDynamatrix(
          */
 
 //CLS//
-        return {
+        return { ->
 //            script.stage(stageName) {
                 if (dsbc.enableDebugTrace) script.echo "Running stage: ${stageName}" + "\n  for ${Utils.castString(dsbc)}"
                 if (dsbc.isAllowedFailure) {

--- a/src/org/nut/dynamatrix/Dynamatrix.groovy
+++ b/src/org/nut/dynamatrix/Dynamatrix.groovy
@@ -1208,7 +1208,7 @@ def parallelStages = prepareDynamatrix(
 //CLS//
         return { ->
 //            script.stage(stageName) {
-                if (dsbc.enableDebugTrace) script.echo "Running stage: ${stageName}" + "\n  for ${Utils.castString(dsbc)}"
+                if (dsbc.enableDebugTrace) script.echo "Running stage: ${stageName}" + "\n  for ${Utils.castString(dsbc)}" + (body == null ? "\n  with a NULL body" : "")
                 if (dsbc.isAllowedFailure) {
                     script.catchError(
                         message: "Failed stage which is allowed to fail: ${stageName}" + "\n  for ${Utils.castString(dsbc)}",

--- a/src/org/nut/dynamatrix/Dynamatrix.groovy
+++ b/src/org/nut/dynamatrix/Dynamatrix.groovy
@@ -251,6 +251,8 @@ class Dynamatrix implements Cloneable {
             }
         }
 
+/*
+        // Seems we can not "remove" a summary entry, despite what the docs say
         try {
             this.script.removeBadges(id: "Build-progress-summary@" + this.objectID)
         } catch (Throwable tOK) { // ok if missing
@@ -259,6 +261,7 @@ class Dynamatrix implements Cloneable {
                 this.script.echo (t.toString())
             }
         }
+*/
         if (removeOnly) return true
 
         // Stage finished, update the rolling progress via GPBP steps (with id)
@@ -289,17 +292,19 @@ class Dynamatrix implements Cloneable {
             res = false
         }
 
+/*
         try {
             // Roll a text entry in the build overview page
             this.script.createSummary(icon: 'info.gif', text: txt, id: "Build-progress-summary@" + this.objectID)
             if (res == null) res = true
         } catch (Throwable t) {
-            this.script.echo "WARNING: Tried to createSummary() for 'Build-progress-badge@${this.objectID}', but failed to; are the Groovy Postbuild plugin and jenkins-badge-plugin installed?"
+            this.script.echo "WARNING: Tried to createSummary() for 'Build-progress-summary@${this.objectID}', but failed to; are the Groovy Postbuild plugin and jenkins-badge-plugin installed?"
             if (this.shouldDebugTrace()) {
                 this.script.echo (t.toString())
             }
             res = false
         }
+*/
 
         return res
     }

--- a/src/org/nut/dynamatrix/Dynamatrix.groovy
+++ b/src/org/nut/dynamatrix/Dynamatrix.groovy
@@ -1121,7 +1121,8 @@ def parallelStages = prepareDynamatrix(
         return dsbcSet
     } // generateBuildConfigSet()
 
-    private Closure generatedBuildWrapperLayer2 (String stageName, DynamatrixSingleBuildConfig dsbc, Closure body = null) {
+    //private Closure generatedBuildWrapperLayer2 (String stageName, DynamatrixSingleBuildConfig dsbc, Closure body = null) {
+    private Closure generatedBuildWrapperLayer2 (stageName, dsbc, body = null) {
         /* Helper for generatedBuild() below to not repeat the
          * same code structure in different handled situations
          */
@@ -1188,7 +1189,8 @@ def parallelStages = prepareDynamatrix(
 
     }
 
-    private Closure generatedBuildWrapperLayer1 (String stageName, DynamatrixSingleBuildConfig dsbc, Closure body = null) {
+    //private Closure generatedBuildWrapperLayer1 (String stageName, DynamatrixSingleBuildConfig dsbc, Closure body = null) {
+    private Closure generatedBuildWrapperLayer1 (stageName, dsbc, body = null) {
         /* Helper for generatedBuild() below to not repeat the
          * same code structure in different handled situations.
          * The stageName may be hard to (re-)calculate and/or

--- a/src/org/nut/dynamatrix/Dynamatrix.groovy
+++ b/src/org/nut/dynamatrix/Dynamatrix.groovy
@@ -1228,7 +1228,10 @@ def parallelStages = prepareDynamatrix(
     // ...
     // FAILED 'Build' for (ARCH_BITS=64&&ARCH64=amd64&&COMPILER=CLANG&&CLANGVER=10&&OS_DISTRO=freebsd12&&OS_FAMILY=bsd) && (nut-builder) && BITS=64&&CSTDVARIANT=c&&CSTDVERSION_c=99&&CSTDVERSION_cxx=98  &&  LANG=C && LC_ALL=C && TZ=UTC (isAllowedFailure)
     // ... so which platform was it really? which test case? expected fault or not?
-    def generateParstageWithoutAgent(def script, def dsbc, def stageName, def sbName, Closure payload) {
+
+    // NOTE: Seems that to ensure object locality, arguments SHOULD NOT be
+    // declared with "def" or a specific type"
+    def generateParstageWithoutAgent(script, dsbc, stageName, sbName, payload) {
         return { ->
             if (dsbc.enableDebugTrace) script.echo "Not requesting any node for stage '${stageName}'" + sbName
             payload()
@@ -1236,7 +1239,7 @@ def parallelStages = prepareDynamatrix(
     }
 
 
-    def generateParstageWithAgentBLE(def script, def dsbc, def stageName, def sbName, Closure payload) {
+    def generateParstageWithAgentBLE(script, dsbc, stageName, sbName, payload) {
         return { ->
             if (dsbc.enableDebugTrace) script.echo "Requesting a node by label expression '${dsbc.buildLabelExpression}' for stage '${stageName}'" + sbName
             script.node (dsbc.buildLabelExpression) {
@@ -1246,7 +1249,7 @@ def parallelStages = prepareDynamatrix(
         }
     }
 
-    def generateParstageWithAgentAnon(def script, def dsbc, def stageName, def sbName, Closure payload) {
+    def generateParstageWithAgentAnon(script, dsbc, stageName, sbName, payload) {
         return { ->
             if (dsbc.enableDebugTrace) script.echo "Requesting any node for stage '${stageName}'" + sbName
             script.node {

--- a/src/org/nut/dynamatrix/Dynamatrix.groovy
+++ b/src/org/nut/dynamatrix/Dynamatrix.groovy
@@ -245,7 +245,12 @@ class Dynamatrix implements Cloneable {
         try {
             try {
                 this.script.removeBadges(id: "Build-progress@" + this.objectID)
-            } catch (Throwable tOK) {} // ok if missing
+            } catch (Throwable tOK) { // ok if missing
+                this.script.echo "WARNING: Tried to removeBadges() for 'Build-progress@${this.objectID}', but failed to; are the Groovy Postbuild plugin and jenkins-badge-plugin installed?"
+                if (this.shouldDebugTrace()) {
+                    this.script.echo (t.toString())
+                }
+            }
             if (removeOnly) return true
 
             // Stage finished, update the rolling progress via GPBP steps (with id)

--- a/src/org/nut/dynamatrix/Dynamatrix.groovy
+++ b/src/org/nut/dynamatrix/Dynamatrix.groovy
@@ -135,6 +135,18 @@ class Dynamatrix implements Cloneable {
     }
 
     @NonCPS
+    synchronized public Map<Result, Set<String>> reportStageResults() {
+        def mapres = [:]
+        this.trackStageResults.each { sn, r ->
+            if (!mapres.containsKey(r)) {
+                mapres[r] = []
+            }
+            mapres[r] << sn
+        }
+        return mapres
+    }
+
+    @NonCPS
     synchronized public Integer countStagesIncrement(Result r) {
         return this.countStagesIncrement(r?.toString())
     }

--- a/src/org/nut/dynamatrix/DynamatrixSingleBuildConfig.groovy
+++ b/src/org/nut/dynamatrix/DynamatrixSingleBuildConfig.groovy
@@ -576,11 +576,17 @@ class DynamatrixSingleBuildConfig implements Cloneable {
         }
 
         boolean res = combos.any {combo ->
-            if (this.matchesConstraintsCombo(combo)) {
-                if (debugTrace)
-                    this.script.println ("[DEBUG] matchesConstraints(): ${Utils.castString(this)} " +
-                        "matched ${Utils.castString(combo)}")
-                return true // break with a hit
+            // No combo - no hit, extracted from matchesConstraintsCombo() to log more error details2
+            if (Utils.isListNotEmpty(combo)) {
+                if (this.matchesConstraintsCombo(combo)) {
+                    if (debugTrace)
+                        this.script.println ("[DEBUG] matchesConstraints(): ${Utils.castString(this)} " +
+                            "matched ${Utils.castString(combo)}")
+                    return true // break with a hit
+                }
+            } else {
+                if (debugErrors) this.script.println ("[ERROR] matchesConstraints(): got invalid input item: ${Utils.castString(combo)} while looking at a Set of combos: ${Utils.castString(combos)}")
+                return false // continue looping
             }
             return false // continue looping
         }

--- a/vars/buildMatrixCellCI.groovy
+++ b/vars/buildMatrixCellCI.groovy
@@ -217,6 +217,11 @@ set +x
 """
         }
 
+        // Remember where to get the logs
+        if (dsbc?.thisDynamatrix) {
+            dsbc.thisDynamatrix.setLogKey(stageName, archPrefix)
+        }
+
         // Note: log files below are used for warnings-ng processing
         // and their namesakes will be removed before the build.
         // TODO: invent a way around `git status` violations for projects that care?

--- a/vars/buildMatrixCellCI.groovy
+++ b/vars/buildMatrixCellCI.groovy
@@ -369,23 +369,30 @@ done
         def ia = null
         def cppcheck = null
         def cppcheckAggregated = null
+        // "filters" below help ignore problems in system headers
+        // (with e.g. C90 build mode).
+        // TOTHINK: should we try to get distcheck dirs (like nut-2.4.7.1/*)
+        // to avoid duplicates? Or on the contrary, would we want to see
+        // some bugs in generated dist'ed code even if original does not
+        // have them?
+        def filterSysHeaders = ".*[/\\\\]usr[/\\\\].*\\.(h|hpp)\$"
         switch (compilerTool) {
             case 'gcc':
-                i = scanForIssues tool: gcc(id: id, pattern: '.ci-sanitizedPaths.*.log')
-                ia = scanForIssues tool: gcc(id: 'C/C++ compiler', pattern: '.ci-sanitizedPaths.*.log')
+                i = scanForIssues tool: gcc(id: id, pattern: '.ci-sanitizedPaths.*.log'), filters: [ excludeFile(filterSysHeaders) ]
+                ia = scanForIssues tool: gcc(id: 'C/C++ compiler', pattern: '.ci-sanitizedPaths.*.log'), filters: [ excludeFile(filterSysHeaders) ]
                 break
             case 'gcc3':
-                i = scanForIssues tool: gcc3(id: id, pattern: '.ci-sanitizedPaths.*.log')
-                ia = scanForIssues tool: gcc3(id: 'C/C++ compiler', pattern: '.ci-sanitizedPaths.*.log')
+                i = scanForIssues tool: gcc3(id: id, pattern: '.ci-sanitizedPaths.*.log'), filters: [ excludeFile(filterSysHeaders) ]
+                ia = scanForIssues tool: gcc3(id: 'C/C++ compiler', pattern: '.ci-sanitizedPaths.*.log'), filters: [ excludeFile(filterSysHeaders) ]
                 break
             case 'clang':
-                i = scanForIssues tool: clang(id: id, pattern: '.ci-sanitizedPaths.*.log')
-                ia = scanForIssues tool: clang(id: 'C/C++ compiler', pattern: '.ci-sanitizedPaths.*.log')
+                i = scanForIssues tool: clang(id: id, pattern: '.ci-sanitizedPaths.*.log'), filters: [ excludeFile(filterSysHeaders) ]
+                ia = scanForIssues tool: clang(id: 'C/C++ compiler', pattern: '.ci-sanitizedPaths.*.log'), filters: [ excludeFile(filterSysHeaders) ]
                 break
         }
         if (0 == sh (returnStatus:true, script: """ test -n "`find . -name 'cppcheck*.xml' 2>/dev/null`" """)) {
-            cppcheck = scanForIssues tool: cppCheck(id: id, pattern: '**/cppcheck*.xml')
-            cppcheckAggregated = scanForIssues tool: cppCheck(id: 'CppCheck analyser', pattern: '**/cppcheck*.xml')
+            cppcheck = scanForIssues tool: cppCheck(id: id, pattern: '**/cppcheck*.xml'), filters: [ excludeFile(filterSysHeaders) ]
+            cppcheckAggregated = scanForIssues tool: cppCheck(id: 'CppCheck analyser', pattern: '**/cppcheck*.xml'), filters: [ excludeFile(filterSysHeaders) ]
         }
 
         if (i != null) {

--- a/vars/buildMatrixCellCI.groovy
+++ b/vars/buildMatrixCellCI.groovy
@@ -395,7 +395,7 @@ done
                 ia = scanForIssues tool: clang(id: 'C/C++ compiler', pattern: '.ci-sanitizedPaths.*.log'), filters: [ excludeFile(filterSysHeaders) ]
                 break
         }
-        if (0 == sh (returnStatus:true, script: """ test -n "`find . -name 'cppcheck*.xml' 2>/dev/null`" """)) {
+        if (0 == sh (returnStatus:true, script: """ test -n "`find . -name 'cppcheck*.xml' 2>/dev/null`" && echo "Found cppcheck XML reports" """)) {
             cppcheck = scanForIssues tool: cppCheck(id: id, pattern: '**/cppcheck*.xml'), filters: [ excludeFile(filterSysHeaders) ]
             cppcheckAggregated = scanForIssues tool: cppCheck(id: 'CppCheck analyser', pattern: '**/cppcheck*.xml'), filters: [ excludeFile(filterSysHeaders) ]
         }

--- a/vars/dynamatrixPipeline.groovy
+++ b/vars/dynamatrixPipeline.groovy
@@ -656,6 +656,9 @@ def call(dynacfgBase = [:], dynacfgPipeline = [:]) {
                 if (dynamatrixGlobalState.enableDebugTrace)
                     echo dynamatrix.toStringStageCountDump()
 
+                // Build finished, remove the rolling progress via GPBP steps (with id)
+                dynamatrix.updateProgressBadge(true)
+
                 if (currentBuild.result in [null, 'SUCCESS']) {
                     // Report success as a badge too, so interrupted incomplete
                     // builds (Jenkins/server restart etc.) are more visible

--- a/vars/dynamatrixPipeline.groovy
+++ b/vars/dynamatrixPipeline.groovy
@@ -655,7 +655,7 @@ def call(dynacfgBase = [:], dynacfgPipeline = [:]) {
                             mapres.each { r, sns ->
                                 txt = "<nl>Result: ${r.toString()} (${sns.size()}):\n"
                                 sns.each { sn ->
-                                    txt += "<li>${sn}<li/>\n"
+                                    txt += "<li>${sn}</li>\n"
                                 }
                                 txt += "</nl>\n"
                                 createSummary(text: txt, icon: '/images/48x48/warning.png')

--- a/vars/dynamatrixPipeline.groovy
+++ b/vars/dynamatrixPipeline.groovy
@@ -656,7 +656,29 @@ def call(dynacfgBase = [:], dynacfgPipeline = [:]) {
                 if (dynamatrixGlobalState.enableDebugTrace)
                     echo dynamatrix.toStringStageCountDump()
 
-                if (!(currentBuild.result in [null, 'SUCCESS'])) {
+                if (currentBuild.result in [null, 'SUCCESS']) {
+                    // Report success as a badge too, so interrupted incomplete
+                    // builds (Jenkins/server restart etc.) are more visible
+                    try {
+                        def txt = dynamatrix.toStringStageCountNonZero()
+                        if (!(Utils.isStringNotEmpty(txt))) {
+                            txt = dynamatrix.toStringStageCountDumpNonZero()
+                        }
+                        if (!(Utils.isStringNotEmpty(txt))) {
+                            txt = dynamatrix.toStringStageCountDump()
+                        }
+                        if (!(Utils.isStringNotEmpty(txt))) {
+                            txt = dynamatrix.toStringStageCount()
+                        }
+
+                        def txtOK = "Build completed successfully"
+                        manager.addShortText(txtOK)
+                        createSummary(text: txtOK + ": " + txt, icon: '/images/48x48/notepad.png')
+                    } catch (Throwable t) {
+                        echo "WARNING: Tried to addShortText() and createSummary(), but failed to; are the Groovy Postbuild plugin and jenkins-badge-plugin installed?"
+                        if (dynamatrixGlobalState.enableDebugTrace) echo t.toString()
+                    }
+                } else {
                     try {
                         def txt = dynamatrix.toStringStageCountNonZero()
                         if (!(Utils.isStringNotEmpty(txt))) {

--- a/vars/dynamatrixPipeline.groovy
+++ b/vars/dynamatrixPipeline.groovy
@@ -518,7 +518,7 @@ def call(dynacfgBase = [:], dynacfgPipeline = [:]) {
                         // that Jenkins adds):
                         if (sbSummaryCount != "") {
                             // Note: replace goes by regex so '\*'
-                            sbSummaryCount = sbSummaryCount.replaceAll('\n\t\\* ', '</li><li>').replaceFirst('</li>', '<ul>Detailed hit counts:') + '</li></ul>'
+                            sbSummaryCount = sbSummaryCount.replaceAll('\n\t\\* ', '</li><li>').replaceFirst('</li>', '<p>Detailed hit counts:<ul>') + '</li></ul></p>'
                         }
                         createSummary(text: sbSummary + sbSummaryCount, icon: '/images/48x48/notepad.png')
                     } catch (Throwable t) {
@@ -675,14 +675,14 @@ def call(dynacfgBase = [:], dynacfgPipeline = [:]) {
                                     txt += "<li>${sn}"
                                     if (archPrefix) {
                                         // File naming as defined in vars/buildMatrixCellCI.groovy
-                                        txt += "\n<ul>See build artifacts keyed with: '${archPrefix}' e.g.:\n"
+                                        txt += "\n<p>See build artifacts keyed with: '${archPrefix}' e.g.:<ul>\n"
                                         for (url in [
                                             "${env.BUILD_URL}/artifact/.ci.${archPrefix}.config.log.gz",
                                             "${env.BUILD_URL}/artifact/.ci.${archPrefix}.build.log.gz"
                                         ]) {
                                             txt += "<li><a href='${url}'>${url}</a></li>\n"
                                         }
-                                        txt += "</ul>"
+                                        txt += "</ul></p>"
                                     }
                                     txt += "</li>\n"
                                 }

--- a/vars/dynamatrixPipeline.groovy
+++ b/vars/dynamatrixPipeline.groovy
@@ -655,7 +655,16 @@ def call(dynacfgBase = [:], dynacfgPipeline = [:]) {
                             mapres.each { r, sns ->
                                 txt = "<nl>Result: ${r.toString()} (${sns.size()}):\n"
                                 sns.each { sn ->
-                                    txt += "<li>${sn}</li>\n"
+                                    def archPrefix = dynamatrix.getLogKey(sn)
+                                    txt += "<li>${sn}"
+                                    if (archPrefix) {
+                                        // File naming as defined in vars/buildMatrixCellCI.groovy
+                                        txt += "\n<ul>See build artifacts keyed with: '${archPrefix}' e.g.:\n"
+                                        txt += "<li>${env.BUILD_URL}/artifact/.ci.${archPrefix}.config.log.gz</li>\n"
+                                        txt += "<li>${env.BUILD_URL}/artifact/.ci.${archPrefix}.build.log.gz</li>\n"
+                                        txt += "</ul>"
+                                    }
+                                    txt += "</li>\n"
                                 }
                                 txt += "</nl>\n"
                                 createSummary(text: txt, icon: '/images/48x48/warning.png')

--- a/vars/dynamatrixPipeline.groovy
+++ b/vars/dynamatrixPipeline.groovy
@@ -486,6 +486,16 @@ def call(dynacfgBase = [:], dynacfgPipeline = [:]) {
                             txt += sbSummaryCount
                             writeFile(file: ".ci.slowBuildStages-list.txt", text: txt)
                             archiveArtifacts (artifacts: ".ci.slowBuildStages-list.txt", allowEmptyArchive: true)
+
+                            try {
+                                createSummary(text: "Saved the list of slowBuild stages into a text artifact " +
+                                    "<a href='${env.BUILD_URL}/artifact/.ci.slowBuildStages-list.txt'>.ci.slowBuildStages-list.txt</a>",
+                                    icon: '/images/48x48/notepad.png')
+                            } catch (Throwable ts) {
+                                echo "WARNING: Tried to addInfoBadge() and createSummary(), but failed to; is the jenkins-badge-plugin installed?"
+                                if (dynamatrixGlobalState.enableDebugTrace) echo t.toString()
+                            }
+
                         } catch (Throwable t) {
                             echo "WARNING: Tried to save the list of slowBuild stages into a text artifact '.ci.slowBuildStages-list.txt', but failed to"
                             if (dynamatrixGlobalState.enableDebugTrace) echo t.toString()

--- a/vars/dynamatrixPipeline.groovy
+++ b/vars/dynamatrixPipeline.groovy
@@ -345,7 +345,7 @@ def call(dynacfgBase = [:], dynacfgPipeline = [:]) {
                                 // CHANGE_BRANCH with the original value.
                                 if (!(env.BRANCH_NAME ==~ sb.branchRegexSource)) {
                                     if (dynamatrixGlobalState.enableDebugTrace || sb?.name)
-                                        echo "SKIP: Source branch name '${env.BRANCH_NAME}' did not match the pattern ${sb.branchRegexSource} for this slow build filter configuration" + (sb?.name ? ": " + sb.name : "")
+                                        echo "SKIP: Source branch name '${env.BRANCH_NAME}' did not match the pattern ~/${sb.branchRegexSource}/ for this slow build filter configuration" + (sb?.name ? ": " + sb.name : "")
                                     countFiltersSkipped++
                                     return // continue
                                 }
@@ -356,7 +356,7 @@ def call(dynacfgBase = [:], dynacfgPipeline = [:]) {
                                 && (!(env.CHANGE_TARGET ==~ sb.branchRegexTarget))
                                 ) {
                                     if (dynamatrixGlobalState.enableDebugTrace || sb?.name)
-                                        echo "SKIP: Target branch name '${env.CHANGE_TARGET}' did not match the pattern ${sb.branchRegexTarget} for this slow build filter configuration" + (sb?.name ? ": " + sb.name : "")
+                                        echo "SKIP: Target branch name '${env.CHANGE_TARGET}' did not match the pattern ~/${sb.branchRegexTarget}/ for this slow build filter configuration" + (sb?.name ? ": " + sb.name : "")
                                     countFiltersSkipped++
                                     return // continue
                                 } // else: CHANGE_TARGET is empty (probably not
@@ -377,7 +377,7 @@ def call(dynacfgBase = [:], dynacfgPipeline = [:]) {
                                 && (!(_CHANGE_TARGET ==~ sb.branchRegexTarget))
                                 ) {
                                     if (dynamatrixGlobalState.enableDebugTrace || sb?.name)
-                                        echo "SKIP: Target branch name '${_CHANGE_TARGET}' did not match the pattern ${sb.branchRegexTarget} for this slow build filter configuration" + (sb?.name ? ": " + sb.name : "")
+                                        echo "SKIP: Target branch name '${_CHANGE_TARGET}' did not match the pattern ~/${sb.branchRegexTarget}/ for this slow build filter configuration" + (sb?.name ? ": " + sb.name : "")
                                     countFiltersSkipped++
                                     return // continue
                                 }
@@ -389,7 +389,7 @@ def call(dynacfgBase = [:], dynacfgPipeline = [:]) {
                                     // builds, they can use the source branch
                                     // regex set to /^PR-\d+$/
                                     if (dynamatrixGlobalState.enableDebugTrace || sb?.name)
-                                        echo "NOTE: Target branch name is not set for this build (not a PR?), so ignoring the pattern ${sb.branchRegexTarget} set for this slow build filter configuration" + (sb?.name ? ": " + sb.name : "")
+                                        echo "NOTE: Target branch name is not set for this build (not a PR?), so ignoring the pattern ~/${sb.branchRegexTarget}/ set for this slow build filter configuration" + (sb?.name ? ": " + sb.name : "")
                                         // NOT a "skip", just a "FYI"!
                                 }
                             } // if branchRegexTarget

--- a/vars/dynamatrixPipeline.groovy
+++ b/vars/dynamatrixPipeline.groovy
@@ -492,7 +492,7 @@ def call(dynacfgBase = [:], dynacfgPipeline = [:]) {
                                     "<a href='${env.BUILD_URL}/artifact/.ci.slowBuildStages-list.txt'>.ci.slowBuildStages-list.txt</a>",
                                     icon: '/images/48x48/notepad.png')
                             } catch (Throwable ts) {
-                                echo "WARNING: Tried to addInfoBadge() and createSummary(), but failed to; is the jenkins-badge-plugin installed?"
+                                echo "WARNING: Tried to createSummary(), but failed to; is the jenkins-badge-plugin installed?"
                                 if (dynamatrixGlobalState.enableDebugTrace) echo t.toString()
                             }
 

--- a/vars/dynamatrixPipeline.groovy
+++ b/vars/dynamatrixPipeline.groovy
@@ -676,8 +676,12 @@ def call(dynacfgBase = [:], dynacfgPipeline = [:]) {
                                     if (archPrefix) {
                                         // File naming as defined in vars/buildMatrixCellCI.groovy
                                         txt += "\n<ul>See build artifacts keyed with: '${archPrefix}' e.g.:\n"
-                                        txt += "<li>${env.BUILD_URL}/artifact/.ci.${archPrefix}.config.log.gz</li>\n"
-                                        txt += "<li>${env.BUILD_URL}/artifact/.ci.${archPrefix}.build.log.gz</li>\n"
+                                        for (url in [
+                                            "${env.BUILD_URL}/artifact/.ci.${archPrefix}.config.log.gz",
+                                            "${env.BUILD_URL}/artifact/.ci.${archPrefix}.build.log.gz"
+                                        ]) {
+                                            txt += "<li><a href='${url}'>${url}</a></li>\n"
+                                        }
                                         txt += "</ul>"
                                     }
                                     txt += "</li>\n"

--- a/vars/dynamatrixPipeline.groovy
+++ b/vars/dynamatrixPipeline.groovy
@@ -465,10 +465,9 @@ def call(dynacfgBase = [:], dynacfgPipeline = [:]) {
                     String sbSummarySuffix = "'slow build' configurations over ${countFiltersSeen} filter definition(s) tried " +
                         "(${countFiltersSkipped} dynacfgPipeline.slowBuild elements were skipped due to build circumstances or as invalid)"
                     String sbSummary = null
-                    String sbSummaryCount = null
+                    String sbSummaryCount = "" // non-null string in any case
                     if (stagesBinBuild.size() == 0) {
                         sbSummary = "Did not discover any ${sbSummarySuffix}"
-                        sbSummaryCount = ""
                     } else {
                         sbSummary = "Discovered ${stagesBinBuild.size()} ${sbSummarySuffix}"
                         dynacfgPipeline.slowBuild.each { def sb ->
@@ -518,7 +517,8 @@ def call(dynacfgBase = [:], dynacfgPipeline = [:]) {
                         // path here is somewhat relative to /static/hexhash/
                         // that Jenkins adds):
                         if (sbSummaryCount != "") {
-                            sbSummaryCount = sbSummaryCount.replaceAll('\n\t* ', '</li><li>').replaceFirst('</li>', '<ul>Detailed hit counts:') + '</li></ul>'
+                            // Note: replace goes by regex so '\*'
+                            sbSummaryCount = sbSummaryCount.replaceAll('\n\t\\* ', '</li><li>').replaceFirst('</li>', '<ul>Detailed hit counts:') + '</li></ul>'
                         }
                         createSummary(text: sbSummary + sbSummaryCount, icon: '/images/48x48/notepad.png')
                     } catch (Throwable t) {

--- a/vars/dynamatrixPipeline.groovy
+++ b/vars/dynamatrixPipeline.groovy
@@ -645,6 +645,22 @@ def call(dynacfgBase = [:], dynacfgPipeline = [:]) {
                         txt = "Not all went well: " + txt
                         manager.addShortText(txt)
                         createSummary(text: txt, icon: '/images/48x48/warning.png')
+
+                        // returns Map<Result, Set<String>>
+                        def mapres = dynamatrix.reportStageResults()
+                        if (mapres.containsKey(Result.SUCCESS))
+                            mapres.remove(Result.SUCCESS)
+
+                        if (mapres.size() > 0) {
+                            mapres.each { r, sns ->
+                                txt = "=== Result: ${r.toString()} (${sns.size()})\n"
+                                sns.each { sn ->
+                                    txt += "===== ${sn}\n"
+                                }
+                                txt += "\n"
+                                createSummary(text: txt, icon: '/images/48x48/warning.png')
+                            }
+                        }
                     } catch (Throwable t) {
                         echo "WARNING: Tried to addShortText() and createSummary(), but failed to; are the Groovy Postbuild plugin and jenkins-badge-plugin installed?"
                         if (dynamatrixGlobalState.enableDebugTrace) echo t.toString()

--- a/vars/dynamatrixPipeline.groovy
+++ b/vars/dynamatrixPipeline.groovy
@@ -653,11 +653,11 @@ def call(dynacfgBase = [:], dynacfgPipeline = [:]) {
 
                         if (mapres.size() > 0) {
                             mapres.each { r, sns ->
-                                txt = "=== Result: ${r.toString()} (${sns.size()})\n"
+                                txt = "<nl>Result: ${r.toString()} (${sns.size()}):\n"
                                 sns.each { sn ->
-                                    txt += "===== ${sn}\n"
+                                    txt += "<li>${sn}<li/>\n"
                                 }
-                                txt += "\n"
+                                txt += "</nl>\n"
                                 createSummary(text: txt, icon: '/images/48x48/warning.png')
                             }
                         }


### PR DESCRIPTION
This PR aimed originally to fix the mix-up of build configurations (stageName says one thing, envvars tell another story, due to some re-use of same referenced objects in different parallel stages), by using more closures to dedicate contexts to stuff, but that info seems to be still confused in groovy pipeline engine.

This also addresses better run-time progress and ultimate-results logging for the dynamatrix jobs.