### PR TITLE
Support and maintain optional Gitcache on build agents

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -161,6 +161,46 @@ For certain compiler toolkits (e.g. 'C' family) it would provide an
 automatic preparation of variables for several same-versioned tools
 (e.g. C and C++ compilers).
 
+Declaring additional configuration of build agents
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Depending on their implementation and connectivity, build agents may
+have different preferences, and this library allows to tune them with
+their node labels.
+
+One such area is delivery of tested codebase to the agents: default
+approach which is to stash on master, and unstash on agents, should
+be reliable (should reach agents that can not use the SCM platform
+directly, and should ensure all agents test the same revision even
+if it disappears from the SCM platform -- by e.g. force-push to a PR),
+but at a cost of repetitive traffic and I/O to unstash same code time
+and again (often on same machine) during a matrix build.
+
+Setting `DYNAMATRIX_UNSTASH_PREFERENCE` to `scm-ws`, `scm` or `unstash`
+in the individual agent labels allows that system to start with either
+an SCM checkout augmented by a Git reference repository (persistent) in
+the workspace and maintained during each run (this currently requires
+a custom build of Jenkins Git Client plugin including the feature from
+https://github.com/jenkinsci/git-client-plugin/pull/644 unless/until
+it gets properly merged); or using a plain SCM checkout; or unstashing.
+These methods fall-back from one to next in the order listed above.
+
+The DynamatrixStash methods dealing with code checkout, stashing and
+unstashing, allow a concept of `stashName` used to identify archives
+as well as to track metadata for that codebase (so the same pipeline
+can mix several repositories). Preferences for each repository can
+be tailored, using e.g. `scm:githubProject` and `unstash:privateRepo`
+label values to use different delivery methods for the two stashNames.
+
+To prevent several parallel jobs and build scenarios from corrupting
+the reference repository maintained in the workspace, maintenance of
+this location is protected by Lockable Resources plugin. Since agents
+running with independent storage should not wait on each other, this
+lock can be tuned by setting `DYNAMATRIX_REFREPO_WORKSPACE_LOCKNAME`
+label; note that agents that do indeed use same storage (shared over
+NFS, or using containers with same homedirs from their host) should
+set identical values in their common lock name.
+
 Directory naming
 ~~~~~~~~~~~~~~~~
 

--- a/src/org/nut/dynamatrix/DynamatrixStash.groovy
+++ b/src/org/nut/dynamatrix/DynamatrixStash.groovy
@@ -450,7 +450,7 @@ echo "[DEBUG] Files in `pwd`: `find . -type f | wc -l` and all FS objects under:
             }
 
             if (!scmCommit || !scmURL || ret == false) {
-                script.echo "checkoutCleanSrcRefrepoWS: could not determine build info from SCM, falling back"
+                script.echo "checkoutCleanSrcRefrepoWS: could not determine build info from SCM, falling back: scmCommit='${scmCommit}' scmURL='${scmURL}' ret='${ret}'"
                 checkoutCleanSrc(script, stashCode[stashName])
                 return
             }

--- a/src/org/nut/dynamatrix/DynamatrixStash.groovy
+++ b/src/org/nut/dynamatrix/DynamatrixStash.groovy
@@ -421,19 +421,23 @@ echo "[DEBUG] Files in `pwd`: `find . -type f | wc -l` and all FS objects under:
                 scmCommit = scm?.GIT_COMMIT
                 scmURL = scm?.GIT_URL
                 for (extset in scm?.extensions) {
-                    if (extset.containsKey('$class')) {
-                        switch (extset['$class']) {
-                            case 'SubmoduleOption':
-                                if (!(extset?.disableSubmodules in [null, true])
-                                ||  !(extset?.recursiveSubmodules in [null, false])
-                                ||  !(extset?.trackingSubmodules in [null, false])
-                                ) {
-                                    script.echo "checkoutCleanSrcRefrepoWS: currently no support for submodules"
-                                    ret = false
-                                }
-                                break
-                        } // switch
-                    } // if class
+                    if (Utils.isMapNotEmpty(extset)) {
+                        if (extset.containsKey('$class')) {
+                            switch (extset['$class']) {
+                                case 'SubmoduleOption':
+                                    if (!(extset?.disableSubmodules in [null, true])
+                                    ||  !(extset?.recursiveSubmodules in [null, false])
+                                    ||  !(extset?.trackingSubmodules in [null, false])
+                                    ) {
+                                        script.echo "checkoutCleanSrcRefrepoWS: currently no support for submodules"
+                                        ret = false
+                                    }
+                                    break
+                            } // switch
+                        } // if Map with $class
+                    } else if (extset instanceof hudson.plugins.git.extensions.impl.CloneOption) {
+                        // no-op for now
+                    } // if CloneOption
                 } // for extset
             } else {
                 // Map for checkout()

--- a/src/org/nut/dynamatrix/DynamatrixStash.groovy
+++ b/src/org/nut/dynamatrix/DynamatrixStash.groovy
@@ -415,6 +415,7 @@ echo "[DEBUG] Files in `pwd`: `find . -type f | wc -l` and all FS objects under:
         try {
             String scmCommit = null
             String scmURL = null
+            script.echo "checkoutCleanSrcRefrepoWS: on node '${script?.env?.NODE_NAME}' checking refrepo for '${stashName}'"
             if (scm instanceof hudson.plugins.git.GitSCM) {
                 // GitSCM object
                 scmCommit = scm?.GIT_COMMIT
@@ -445,7 +446,7 @@ echo "[DEBUG] Files in `pwd`: `find . -type f | wc -l` and all FS objects under:
                 return
             }
 
-            script.echo "[DEBUG] checkoutCleanSrcRefrepoWS: node '${script?.env?.NODE_NAME}' waiting for exclusive use of git cache dir"
+            script.echo "[DEBUG] checkoutCleanSrcRefrepoWS: node '${script?.env?.NODE_NAME}' waiting for exclusive use of git cache dir to check out: repo '${scmURL}' commit '${scmCommit}'"
             lock (resource: 'gitcache-dynamatrix', quantity: 1) {
                 // NOTE: Currently this means one lock for all git ops of the CI
                 // farm. An apparent bottleneck to optimize (smartly!) later.

--- a/src/org/nut/dynamatrix/DynamatrixStash.groovy
+++ b/src/org/nut/dynamatrix/DynamatrixStash.groovy
@@ -286,7 +286,7 @@ class DynamatrixStash {
         return s
     }
 
-    static void checkoutCleanSrc(def script, String stashName, Closure scmbody = null) {
+    static def checkoutCleanSrc(def script, String stashName, Closure scmbody = null) {
         return checkoutCleanSrc(script, stashName, true, scmbody)
     }
 
@@ -354,11 +354,11 @@ echo "[DEBUG] Files in `pwd`: `find . -type f | wc -l` and all FS objects under:
         } // node isUnix(), can sh
     }
 
-    static void checkoutCleanSrcNamed(def script, String stashName, Closure scmbody = null) {
+    static def checkoutCleanSrcNamed(def script, String stashName, Closure scmbody = null) {
         return checkoutCleanSrcNamed(script, stashName, true, scmbody)
     }
 
-    static void checkoutCleanSrcNamed(def script, String stashName, Boolean untieRefrepoNow, Closure scmbody = null) {
+    static def checkoutCleanSrcNamed(def script, String stashName, Boolean untieRefrepoNow, Closure scmbody = null) {
         // Different name because groovy gets lost with parameter count
         // when some can be defaulted
 
@@ -368,12 +368,12 @@ echo "[DEBUG] Files in `pwd`: `find . -type f | wc -l` and all FS objects under:
         script.echo "Saving scmbody for ${stashName}: ${Utils.castString(scmbody)}"
         stashCode[stashName] = scmbody
         script.echo "Calling actual checkoutCleanSrc()"
-        checkoutCleanSrc(script, untieRefrepoNow, scmbody)
+        return checkoutCleanSrc(script, untieRefrepoNow, scmbody)
     } // checkoutCleanSrcNamed()
 
-    static void stashCleanSrc(def script, String stashName, Closure scmbody = null) {
+    static def stashCleanSrc(def script, String stashName, Closure scmbody = null) {
         // Optional closure can fully detail how the code is checked out
-        checkoutCleanSrcNamed(script, stashName, scmbody)
+        def res = checkoutCleanSrcNamed(script, stashName, scmbody)
 
         // Be sure to get also "hidden" files like .* in Unix customs => .git*
         // so avoid default exclude patterns
@@ -396,12 +396,13 @@ git status || true
             }
         }
         script.stash (name: stashName, includes: '**,.*,*,.git,.git/**,.git/refs', excludes: '', useDefaultExcludes: false)
+        return res
     } // stashCleanSrc()
 
-    static void unstashScriptedSrc(def script, String stashName) {
+    static def unstashScriptedSrc(def script, String stashName) {
         // only unstashes into current dir() from caller,
         // no pre-cleanup done here (may be in caller)
-        script.unstash (stashName)
+        def res = script.unstash (stashName)
         if (script.isUnix()) {
             // Try a workaround with `git init` per
             // https://issues.jenkins.io/browse/JENKINS-56098?focusedCommentId=380303
@@ -416,6 +417,7 @@ fi
 echo "[DEBUG] Files in `pwd`: `find . -type f | wc -l` and all FS objects under: `find . | wc -l`" || true
 """
         }
+        return res
     }
 
     synchronized static def checkoutCleanSrcRefrepoWS(def script, String stashName) {
@@ -684,7 +686,7 @@ exit \$RET
         return ret
     }
 
-    static void unstashCleanSrc(def script, String stashName) {
+    static def unstashCleanSrc(def script, String stashName) {
         deleteWS(script)
         if (script?.env?.NODE_LABELS) {
             def useMethod = null
@@ -751,7 +753,7 @@ exit \$RET
 
         // Default handling: populate current workspace dir by unstash()
         //script.echo "[D] unstashCleanSrc(): default: calling unstashScriptedSrc"
-        unstashScriptedSrc(script, stashName)
+        return unstashScriptedSrc(script, stashName)
     } // unstashCleanSrc()
 
 } // class DynamatrixStash

--- a/src/org/nut/dynamatrix/DynamatrixStash.groovy
+++ b/src/org/nut/dynamatrix/DynamatrixStash.groovy
@@ -445,7 +445,7 @@ echo "[DEBUG] Files in `pwd`: `find . -type f | wc -l` and all FS objects under:
             }
 
             script.echo "checkoutCleanSrcRefrepoWS: on node '${script?.env?.NODE_NAME}' checking refrepo for '${stashName}'"
-            script.sh "hostname; set | sort -n"
+            //script.sh "hostname; set | sort -n"
             if (scm instanceof hudson.plugins.git.GitSCM) {
                 // GitSCM object
 

--- a/src/org/nut/dynamatrix/DynamatrixStash.groovy
+++ b/src/org/nut/dynamatrix/DynamatrixStash.groovy
@@ -498,7 +498,8 @@ echo "[DEBUG] Files in `pwd`: `find . -type f | wc -l` and all FS objects under:
 git remote -v | grep -w '${scmURL}' || git remote add "`LANG=C TZ=UTC LC_ALL=C date -u | tr ' :,' '_'`" '${scmUrl}' || exit
 RET=0
 git fetch --all || git fetch '${scmURL}' || RET=\$?
-git fetch '${scmURL}' '${scmCommit}' && exit || RET=\$?
+git fetch '${scmURL}' '${scmCommit}' && { sync || true; exit; } || RET=\$?
+sync || true
 exit \$RET
 """)
 
@@ -519,6 +520,7 @@ git fetch 'git-unstash' || git fetch './.git-unstash' || RET=\$?
 git fetch 'git-unstash' '${scmCommit}' || git fetch './.git-unstash' '${scmCommit}' || RET=\$?
 git remote remove 'git-unstash' || RET=\$?
 rm -rf './.git-unstash' || RET=\$?
+sync || true
 exit \$RET
 """)
 

--- a/src/org/nut/dynamatrix/DynamatrixStash.groovy
+++ b/src/org/nut/dynamatrix/DynamatrixStash.groovy
@@ -496,7 +496,10 @@ echo "[DEBUG] Files in `pwd`: `find . -type f | wc -l` and all FS objects under:
                             ret = scipt.sh (label:"Trying direct git fetch from URL ${scmURL} for ${scmCommit}",
                                 script: """
 git remote -v | grep -w '${scmURL}' || git remote add "`LANG=C TZ=UTC LC_ALL=C date -u | tr ' :,' '_'`" '${scmUrl}' || exit
-git fetch --all || git fetch '${scmURL}'
+RET=0
+git fetch --all || git fetch '${scmURL}' || RET=\$?
+git fetch '${scmURL}' '${scmCommit}' && exit || RET=\$?
+exit \$RET
 """)
 
                             if (ret != 0) {
@@ -513,6 +516,7 @@ git fetch --all || git fetch '${scmURL}'
 git remote add 'git-unstash' './.git-unstash' || exit
 RET=0
 git fetch 'git-unstash' || git fetch './.git-unstash' || RET=\$?
+git fetch 'git-unstash' '${scmCommit}' || git fetch './.git-unstash' '${scmCommit}' || RET=\$?
 git remote remove 'git-unstash' || RET=\$?
 rm -rf './.git-unstash' || RET=\$?
 exit \$RET

--- a/src/org/nut/dynamatrix/DynamatrixStash.groovy
+++ b/src/org/nut/dynamatrix/DynamatrixStash.groovy
@@ -416,6 +416,7 @@ echo "[DEBUG] Files in `pwd`: `find . -type f | wc -l` and all FS objects under:
             String scmCommit = null
             String scmURL = null
             script.echo "checkoutCleanSrcRefrepoWS: on node '${script?.env?.NODE_NAME}' checking refrepo for '${stashName}'"
+            script.sh "hostname; set | sort -n"
             if (scm instanceof hudson.plugins.git.GitSCM) {
                 // GitSCM object
                 scmCommit = scm?.GIT_COMMIT

--- a/src/org/nut/dynamatrix/DynamatrixStash.groovy
+++ b/src/org/nut/dynamatrix/DynamatrixStash.groovy
@@ -566,6 +566,7 @@ echo "[DEBUG] Files in `pwd`: `find . -type f | wc -l` and all FS objects under:
                         // check if commit is there (non-fatal)
                         // TODO: generic SCM revision check? Specific GitSCM trick?
                         ret = script.sh (label:"Checking git commit presence for ${scmCommit}",
+                            returnStatus: true,
                             script: "git log -1 '${scmCommit}'")
 
                         if (ret != 0) {
@@ -574,6 +575,7 @@ echo "[DEBUG] Files in `pwd`: `find . -type f | wc -l` and all FS objects under:
                             // Checkout from SCM URL (may fail if
                             // e.g. build agent has no internet)...
                             ret = script.sh (label:"Trying direct git fetch from URL ${scmURL} for ${scmCommit}",
+                                returnStatus: true,
                                 script: """
 git remote -v | grep -w '${scmURL}' || git remote add "`LANG=C TZ=UTC LC_ALL=C date -u | tr ' :,' '_'`" '${scmUrl}' || exit
 RET=0
@@ -592,6 +594,7 @@ exit \$RET
                                     unstashScriptedSrc(script, stashName)
                                 }
 
+                                // here we throw (and catch below) if failed
                                 script.sh (label:"Trying to fetch newest commits from unstashed archive provided by the build",
                                     script: """
 git remote add 'git-unstash' './.git-unstash' || exit
@@ -610,7 +613,8 @@ exit \$RET
                                 }
                             } // if direct git fetch failed
 
-                            ret = script.sh (label:"Checking git commit presence for ${scmCommit} after updating refrepo",
+                            // here we throw (and catch below) if failed
+                            script.sh (label:"Checking git commit presence for ${scmCommit} after updating refrepo",
                                 script: "git log -1 '${scmCommit}'")
                         } // if commit not present
                     //} // neutered withEnv for checking/populating refrepo

--- a/src/org/nut/dynamatrix/DynamatrixStash.groovy
+++ b/src/org/nut/dynamatrix/DynamatrixStash.groovy
@@ -19,8 +19,10 @@ import java.lang.reflect.Modifier;
  * especially if optimizations like Git reference repository local
  * to that worker are involved. Such agents can declare this by
  * specifying a node label DYNAMATRIX_UNSTASH_PREFERENCE=... with
- *   ...=unstash(:stashName)
+ *   ...=scm-ws(:stashName)
  *   ...=scm(:stashName)
+ *   ...=unstash(:stashName)
+ * with fallback handling in this order.
  * The optional ":stashName" suffix allows to limit the preference
  * to builds of a particular project which uses that string, e.g.
  * DYNAMATRIX_UNSTASH_PREFERENCE=scm:nut-ci-src
@@ -41,6 +43,11 @@ import java.lang.reflect.Modifier;
  * '/${GIT_SUBMODULES}' should be verbatim in the expanded envvar:
  *   https://issues.jenkins.io/browse/JENKINS-64383
  *   https://github.com/jenkinsci/git-client-plugin/pull/644
+ *
+ * TODO: Refactor to not abuse GIT_REFERENCE_REPO_DIR for "scm-ws"
+ * checkouts, we can "just populate" the alternates config directly
+ * and avoid confusing Jenkins - it seems to use one definiton for
+ * that envvar across the board, impacting later builds :\
  */
 
 class DynamatrixStash {

--- a/src/org/nut/dynamatrix/DynamatrixStash.groovy
+++ b/src/org/nut/dynamatrix/DynamatrixStash.groovy
@@ -594,7 +594,7 @@ echo "[DEBUG] Files in `pwd`: `find . -type f | wc -l` and all FS objects under:
                             ret = script.sh (label:"Trying direct git fetch from URL ${scmURL} for ${scmCommit}",
                                 returnStatus: true,
                                 script: """
-git remote -v | grep -w '${scmURL}' || git remote add "`LANG=C TZ=UTC LC_ALL=C date -u | tr ' :,' '_'`" '${scmUrl}' || exit
+git remote -v | grep -w '${scmURL}' || git remote add "`LANG=C TZ=UTC LC_ALL=C date -u | tr ' :,' '_'`" '${scmURL}' || exit
 RET=0
 git fetch --all || git fetch '${scmURL}' || RET=\$?
 git fetch '${scmURL}' '${scmCommit}' && { sync || true; exit; } || RET=\$?

--- a/src/org/nut/dynamatrix/DynamatrixStash.groovy
+++ b/src/org/nut/dynamatrix/DynamatrixStash.groovy
@@ -272,7 +272,7 @@ class DynamatrixStash {
             }
         }
 
-        script.echo "checkoutSCM: scmParams = ${Utils.castString(scmParams)}"
+        script.echo "checkoutSCM: running on '${script?.env?.NODE_NAME}' in '${script?.pwd()}', scmParams = ${Utils.castString(scmParams)}"
         return script.checkout(scmParams)
     }
 

--- a/src/org/nut/dynamatrix/DynamatrixStash.groovy
+++ b/src/org/nut/dynamatrix/DynamatrixStash.groovy
@@ -569,10 +569,12 @@ exit \$RET
         if (script?.env?.NODE_LABELS) {
             def useMethod = null
             script.env.NODE_LABELS.split('[ \r\n\t]+').each() { KV ->
+                //script.echo "[D] unstashCleanSrc(): Checking node label '${KV}'"
                 if (KV =~ /^DYNAMATRIX_UNSTASH_PREFERENCE=.*$/) {
                     def key = null
                     def val = null
                     (key, val) = KV.split('=')
+                    //script.echo "[D] unstashCleanSrc(): Checking node label deeper: '${key}'='${val}' (stashName='${stashName}')"
                     if (val == "scm:${stashName}") {
                         useMethod = 'scm'
                     }
@@ -587,6 +589,7 @@ exit \$RET
                             useMethod = val
                         }
                     }
+                    //script.echo "[D] unstashCleanSrc(): From val='${val}' deduced useMethod='${useMethod}'"
                 }
             }
 
@@ -595,6 +598,7 @@ exit \$RET
                     // The stashCode[stashName] should be defined, maybe null,
                     // by an earlier stashCleanSrc() with same stashName.
                     // We error out otherwise, same as would for unstash().
+                    //script.echo "[D] unstashCleanSrc(): ${useMethod}: calling checkoutCleanSrc"
                     checkoutCleanSrc(script, stashCode[stashName])
                     return
                 case 'scm-ws':
@@ -609,13 +613,17 @@ exit \$RET
                         return
                     }
                     // else: got non-null return if behavior is enabled
+                    //script.echo "[D] unstashCleanSrc(): ${useMethod}: calling checkoutCleanSrcRefrepoWS"
                     checkoutCleanSrcRefrepoWS(script, stashName)
                     return
                 // case 'unstash', null, etc: fall through
             }
+
+            //script.echo "[D] unstashCleanSrc(): ${useMethod}: not handled"
         }
 
         // Default handling: populate current workspace dir by unstash()
+        //script.echo "[D] unstashCleanSrc(): default: calling unstashScriptedSrc"
         unstashScriptedSrc(script, stashName)
     } // unstashCleanSrc()
 

--- a/src/org/nut/dynamatrix/DynamatrixStash.groovy
+++ b/src/org/nut/dynamatrix/DynamatrixStash.groovy
@@ -519,6 +519,7 @@ exit \$RET
             } // unlock
         } catch (Throwable t) {
             script.echo "checkoutCleanSrcRefrepoWS: failed to use git refrepo on node '${script?.env?.NODE_NAME}', falling back if we can"
+            script.echo t.toString()
             ret = checkoutCleanSrc(script, stashCode[stashName])
         }
 

--- a/src/org/nut/dynamatrix/DynamatrixStash.groovy
+++ b/src/org/nut/dynamatrix/DynamatrixStash.groovy
@@ -461,8 +461,17 @@ echo "[DEBUG] Files in `pwd`: `find . -type f | wc -l` and all FS objects under:
                     // e.g. "nut/nut/master" or "nut/nut/PR-683" for MBR pipelines
                     refrepoName = script?.env?.JOB_NAME?.replaceLast(/\\/PR-[0-9]+$/, '')
                 }
-                if (!refrepoName) refrepoName = "" // make a big pile
-
+                if (!refrepoName) {
+                    refrepoName = scmURL.replaceLast(/\\.git$/, '')
+                    def rOld = null
+                    while (rOld != refrepoName) {
+                        rOld = refrepoName
+                        refrepoName = refrepoName - ~/^.*\\//
+                    }
+                    refrepoName = refrepoName?.replaceAll(/[^A-Za-z0-9_+-]+/, /_/)
+                }
+                if (!Utils.isStringNotEmpty(refrepoName))
+                    refrepoName = "" // make a big pile
 
                 // Use unique dir name for this repo
                 script.dir (refrepoBase + "/" + refrepoName) {

--- a/src/org/nut/dynamatrix/DynamatrixStash.groovy
+++ b/src/org/nut/dynamatrix/DynamatrixStash.groovy
@@ -242,7 +242,9 @@ class DynamatrixStash {
 // Example object name and spec (from a stacktrace): 'private final
 //   java.lang.String hudson.plugins.git.extensions.impl.CloneOption.reference'
 // with class 'java.lang.reflect.Field'
-                                if (extension.hasProperty('reference') && extension.reference instanceof String) {
+                                if (extension.hasProperty('reference') && extension.reference instanceof String
+                                &&  extension.reference.trim() != refrepo.trim()
+                                ) {
                                     def originalReference = extension.reference
                                     script.print('replacing reference: ' +
                                         originalReference +

--- a/src/org/nut/dynamatrix/DynamatrixStash.groovy
+++ b/src/org/nut/dynamatrix/DynamatrixStash.groovy
@@ -445,6 +445,10 @@ echo "[DEBUG] Files in `pwd`: `find . -type f | wc -l` and all FS objects under:
                 scmCommit = scm?.branches[0]?.name
                 scmURL = scm?.userRemoteConfigs[0]?.url
             }
+            if (scmCommit == null || "${scmCommit}" == "GIT_COMMIT") {
+                scmCommit = script.env.getAt('GIT_COMMIT')
+            }
+
             if (!scmCommit || !scmURL || ret == false) {
                 script.echo "checkoutCleanSrcRefrepoWS: could not determine build info from SCM, falling back"
                 checkoutCleanSrc(script, stashCode[stashName])

--- a/src/org/nut/dynamatrix/DynamatrixStash.groovy
+++ b/src/org/nut/dynamatrix/DynamatrixStash.groovy
@@ -607,14 +607,19 @@ exit \$RET
                     // SCM operation from source or by unstash + update from
                     // this copy) and finally check out current build workspace
                     // using this refrepo. Use locking!
+/*
                     if (!useGitRefrepoDirWS(script)) {
                         script.echo "WARNING: unstashCleanSrc() asked to use 'scm-ws' but it seems not enabled on node '${script?.env?.NODE_NAME}' or globally. Falling back to 'scm'."
                         checkoutCleanSrc(script, stashCode[stashName])
                         return
                     }
                     // else: got non-null return if behavior is enabled
+*/
                     //script.echo "[D] unstashCleanSrc(): ${useMethod}: calling checkoutCleanSrcRefrepoWS"
-                    checkoutCleanSrcRefrepoWS(script, stashName)
+                    script.withEnv(["GIT_REFERENCE_REPO_DIR=WS"]) {
+                        // hack to let code there use the workspace for refrepo
+                        checkoutCleanSrcRefrepoWS(script, stashName)
+                    }
                     return
                 // case 'unstash', null, etc: fall through
             }

--- a/src/org/nut/dynamatrix/dynamatrixGlobalState.groovy
+++ b/src/org/nut/dynamatrix/dynamatrixGlobalState.groovy
@@ -19,6 +19,8 @@ class dynamatrixGlobalState {
     // Something with tools to generate MAN, PDF, HTML... and to spell-check:
     static String labelDocumentationWorker = null
 
+    static Boolean useGitRefrepoDirWS = false
+
     // For build quality evolution analysis, which branch is the reference?
     static String branchDefaultStable = null
 


### PR DESCRIPTION
Closes: #1

With the new (slower) hosting of the NUT CI farm, build time reduction (due to faster instantiation) is astonishing, reaching about 8x in some re-runs during development. This would also finally make it feasible to attach build agents outside the hosted CI farm without prohibitive amounts of traffic (and I/O, and flash wear-out) associated with each build scenario.