### PR TITLE
DynamatrixStash.groovy: avoid manipulating original SCM objects

### DIFF
--- a/src/org/nut/dynamatrix/DynamatrixStash.groovy
+++ b/src/org/nut/dynamatrix/DynamatrixStash.groovy
@@ -632,7 +632,7 @@ echo "[DEBUG] Files in `pwd`: `find . -type f | wc -l` and all FS objects under:
                             ret = script.sh (label:"Trying direct git fetch from URL ${scmURL} for ${scmCommit}",
                                 returnStatus: true,
                                 script: """
-git remote -v | grep -w '${scmURL}' || git remote add "`LANG=C TZ=UTC LC_ALL=C date -u | tr ' :,' '_'`" '${scmURL}' || exit
+git remote -v | grep -w '${scmURL}' || git remote add "`LANG=C TZ=UTC LC_ALL=C date -u | tr ' :,' '_'`_\$\$" '${scmURL}' || exit
 RET=0
 git fetch --all || git fetch '${scmURL}' || RET=\$?
 git fetch '${scmURL}' '${scmCommit}' && { sync || true; exit; } || RET=\$?

--- a/src/org/nut/dynamatrix/DynamatrixStash.groovy
+++ b/src/org/nut/dynamatrix/DynamatrixStash.groovy
@@ -308,7 +308,10 @@ class DynamatrixStash {
 
         // Per https://plugins.jenkins.io/workflow-scm-step/ the common
         // "scm" is a Map maintained by the pipeline, so we can tweak it
-        def scm = script.scm
+        // Per other observations, it can be e.g. a GitSCM object instead.
+        // In any case, use a clone to avoid manipulating options of the
+        // original object (refrepo, etc.) when tuning individual builds.
+        def scm = script?.scm?.clone()
 
         def res = null
 
@@ -445,7 +448,7 @@ echo "[DEBUG] Files in `pwd`: `find . -type f | wc -l` and all FS objects under:
         // See also:
         //   https://stackoverflow.com/questions/36581015/accessing-the-current-jenkins-build-in-groovy-script
 
-        def scm = script.scm
+        def scm = script?.scm?.clone()
 
         if (!(Utils.isMap(scm)
               && scm.containsKey('$class')


### PR DESCRIPTION
When we use preference (scm/scm-ws) that can inject a build-agent dependent refrepo path into "script.scm" object, avoid doing that to the object shared by the build (and apparently beyond - seems to impact starting refrepo for next builds too, so the Jenkins controller tries to check out with refrepo path relevant for last used agents).

This change hopefully fixes that.