### PR TITLE
Javadoc'ize the codebase and at least `def` all method and iterator types

### DIFF
--- a/src/org/nut/dynamatrix/Dynamatrix.groovy
+++ b/src/org/nut/dynamatrix/Dynamatrix.groovy
@@ -242,7 +242,7 @@ class Dynamatrix implements Cloneable {
                     // a sub-set or super-set of the "sn". We want to keep
                     // the longer version to help troubleshooting.
                     def trackedSN = null
-                    this.trackStageResults.each { tsk, tsr ->
+                    this.trackStageResults.each {String tsk, Result tsr ->
                         if (tsk.startsWith(sn) || sn.startsWith(tsk)) {
                             trackedSN = tsk
                             return true
@@ -302,7 +302,7 @@ class Dynamatrix implements Cloneable {
         }
 
         def k = null
-        trackStageLogkeys.each { sn, lk ->
+        trackStageLogkeys.each {String sn, String lk ->
             if (Utils.isStringNotEmpty(sn)
             &&  (sn.startsWith(s) || s.startsWith(sn))
             ) {
@@ -324,7 +324,7 @@ class Dynamatrix implements Cloneable {
     @NonCPS
     synchronized public Map<Result, Set<String>> reportStageResults() {
         def mapres = [:]
-        this.trackStageResults.each { sn, r ->
+        this.trackStageResults.each {String sn, Result r ->
             if (!mapres.containsKey(r)) {
                 mapres[r] = []
             }
@@ -516,7 +516,7 @@ class Dynamatrix implements Cloneable {
         this.enableDebugSysprint = dynamatrixGlobalState.enableDebugSysprint
     }
 
-    public boolean canEqual(java.lang.Object other) {
+    public boolean canEqual(Object other) {
         return other instanceof Dynamatrix
     }
 
@@ -608,7 +608,7 @@ class Dynamatrix implements Cloneable {
      */
     public String toStringStageCountDumpNonZero() {
         def m = [:]
-        countStages.each {k, v ->
+        countStages.each {String k, Integer v ->
             if (v > 0) m[k] = v
         }
         return m.toString()
@@ -735,7 +735,7 @@ def parallelStages = prepareDynamatrix(
      * @see #clearMapNeedsPrepareDynamatrixClone
      * @see #prepareDynamatrix
      */
-    def needsPrepareDynamatrixClone(dynacfgOrig = [:]) {
+    def needsPrepareDynamatrixClone(Map dynacfgOrig = [:]) {
         if (Utils.isListNotEmpty(dynacfgOrig?.requiredNodelabels)) {
             if (Utils.isListNotEmpty(dynacfg.requiredNodelabels)) {
                 if (dynacfg.requiredNodelabels != dynacfgOrig.requiredNodelabels) {
@@ -796,7 +796,7 @@ def parallelStages = prepareDynamatrix(
      * @see #needsPrepareDynamatrixClone
      * @see #prepareDynamatrix
      */
-    static def clearMapNeedsPrepareDynamatrixClone(dynacfgOrig = [:]) {
+    static def clearMapNeedsPrepareDynamatrixClone(Map dynacfgOrig = [:]) {
         def dc = dynacfgOrig.clone()
         if (dc?.commonLabelExpr)
             dc.remove('commonLabelExpr')
@@ -818,7 +818,7 @@ def parallelStages = prepareDynamatrix(
      * @see #clearMapNeedsPrepareDynamatrixClone
      * @see #prepareDynamatrix
      */
-    def clearNeedsPrepareDynamatrixClone(dynacfgOrig = [:]) {
+    def clearNeedsPrepareDynamatrixClone(Map dynacfgOrig = [:]) {
         def debugTrace = this.shouldDebugTrace()
         if (debugTrace) this.script.println "[DEBUG] prepareDynamatrix(): Clearing certain pre-existing data points from dynacfg object"
         this.dynacfg.clearNeedsPrepareDynamatrixClone(dynacfgOrig)
@@ -842,7 +842,7 @@ def parallelStages = prepareDynamatrix(
      * @see #clearMapNeedsPrepareDynamatrixClone
      * @see #needsPrepareDynamatrixClone
      */
-    def prepareDynamatrix(dynacfgOrig = [:]) {
+    def prepareDynamatrix(Map dynacfgOrig = [:]) {
         def debugErrors = this.shouldDebugErrors()
         def debugTrace = this.shouldDebugTrace()
         def debugMilestones = this.shouldDebugMilestones()
@@ -917,7 +917,7 @@ def parallelStages = prepareDynamatrix(
         // sets of exact axis names, e.g. ['ARCH', 'CLANGVER', 'OS'] and
         // ['ARCH', 'GCCVER', 'OS'] as expanded from '${COMPILER}VER' part:
         this.effectiveAxes = []
-        dynacfg.dynamatrixAxesLabels.each() {axis ->
+        dynacfg.dynamatrixAxesLabels.each() {def axis ->
             //TreeSet effAxis = this.nodeCaps.resolveAxisName(axis).sort()
             //TreeSet effAxis = nodeCaps.resolveAxisName(axis).sort()
             TreeSet effAxis = tmpNodeCaps.resolveAxisName(axis).sort()
@@ -975,16 +975,16 @@ def parallelStages = prepareDynamatrix(
         }
         //this.nodeCaps.
         //nodeCaps.
-        tmpNodeCaps.nodeData.keySet().each() {nodeName ->
+        tmpNodeCaps.nodeData.keySet().each() {String nodeName ->
             // Looking at each node separately allows us to be sure that any
             // combo of axis-values (all of which it allegedly provides)
             // can be fulfilled
             def nodeAxisCombos = []
-            this.effectiveAxes.each() {axisSet ->
+            this.effectiveAxes.each() {def axisSet ->
                 // Now looking at one definitive set of axis names that
                 // we would pick supported values for, by current node:
                 def axisCombos = []
-                axisSet.each() {axis ->
+                axisSet.each() {def axis ->
                     if (debugTrace) this.script.println "[DEBUG] prepareDynamatrix(): querying values for axis '${Utils.castString(axis)}' collected for node '${Utils.castString(nodeName)}'..."
                     //def tmpset = this.nodeCaps.resolveAxisValues(axis, nodeName, true)
                     //def tmpset = nodeCaps.resolveAxisValues(axis, nodeName, true)
@@ -1035,8 +1035,8 @@ def parallelStages = prepareDynamatrix(
         // ]
 
         this.buildLabelCombosFlat = []
-        this.buildLabelCombos.each() {nodeResults ->
-            nodeResults.each() {nodeAxisCombos ->
+        this.buildLabelCombos.each() {def nodeResults ->
+            nodeResults.each() {def nodeAxisCombos ->
                 // this nodeResults contains the set of sets of label values
                 // supported for one of the original effectiveAxes requirements,
                 // where each of nodeAxisCombos contains a set of axisValues
@@ -1072,7 +1072,7 @@ def parallelStages = prepareDynamatrix(
         if (Utils.isStringNotEmpty(dynacfg.commonLabelExpr)) {
             if (debugTrace) this.script.println "[DEBUG] prepareDynamatrix(): appending '(${dynacfg.commonLabelExpr}) && ' to buildLabelsAgents combos..."
             def tmp = [:]
-            this.buildLabelsAgents.keySet().each() {ble ->
+            this.buildLabelsAgents.keySet().each() {String ble ->
                 // Note, we only append to the key (node label string for
                 // eventual use in a build), not the value (array of K=V's)
                 tmp["(${ble}) && (${dynacfg.commonLabelExpr})"] = this.buildLabelsAgents[ble]
@@ -1081,7 +1081,7 @@ def parallelStages = prepareDynamatrix(
         }
 
         def blaStr = ""
-        this.buildLabelsAgents.keySet().each() {ble ->
+        this.buildLabelsAgents.keySet().each() {String ble ->
             blaStr += "\n    '${ble}' => " + this.buildLabelsAgents[ble]
         }
         if (debugTrace) this.script.println "[DEBUG] prepareDynamatrix(): detected ${this.buildLabelsAgents.size()} buildLabelsAgents combos:" + blaStr
@@ -1099,8 +1099,8 @@ def parallelStages = prepareDynamatrix(
      */
     static Map mapBuildLabelExpressions(Set<Set> blcSet) {
         /** Equivalent to buildLabelsAgents in the class */
-        def blaMap = [:]
-        blcSet.each() {combo ->
+        Map blaMap = [:]
+        blcSet.each() {Set combo ->
             // Note that labels can be composite, e.g. "COMPILER=GCC GCCVER=1.2.3"
             // ble == build label expression
             String ble = String.join('&&', combo).replaceAll('\\s+', '&&')
@@ -1111,7 +1111,7 @@ def parallelStages = prepareDynamatrix(
 
     /** Returns a set of (unique) {@link DynamatrixSingleBuildConfig} items */
 //    @NonCPS
-    def generateBuildConfigSet(dynacfgOrig = [:]) {
+    def generateBuildConfigSet(Map dynacfgOrig = [:]) {
         def debugErrors = this.shouldDebugErrors()
         def debugTrace = this.shouldDebugTrace()
         def debugMilestones = this.shouldDebugMilestones()
@@ -1152,7 +1152,7 @@ def parallelStages = prepareDynamatrix(
             // Map of "axis: [array, of, values]"
             if (debugTrace) this.script.println "[DEBUG] generateBuildConfigSet(): dynamatrixAxesVirtualLabelsMap: ${dynacfgBuild.dynamatrixAxesVirtualLabelsMap}"
             Set dynamatrixAxesVirtualLabelsCombos = []
-            dynacfgBuild.dynamatrixAxesVirtualLabelsMap.keySet().each() {k ->
+            dynacfgBuild.dynamatrixAxesVirtualLabelsMap.keySet().each() {def k ->
                 // Keys of the map, e.g. 'CSTDVARIANT' for strings ('c', 'gnu')
                 // or 'CSTDVERSION_${KEY}' for submaps (['c': '99', 'cxx': '98'])
                 def vals = dynacfgBuild.dynamatrixAxesVirtualLabelsMap[k]
@@ -1163,12 +1163,12 @@ def parallelStages = prepareDynamatrix(
 
                 // Collect possible values of this one key
                 Set keyvalues = []
-                vals.each() {v ->
+                vals.each() {def v ->
                     // Store each value of the provided axis as a set with
                     // one item (if a string) or more (if an expanded map)
                     Set vv = []
                     if (Utils.isMap(v) && k.contains('${KEY}')) {
-                        v.keySet().each() {subk ->
+                        v.keySet().each() {def subk ->
                             def dk = k.replaceFirst(/\$\{KEY\}/, subk)
                             vv << "${dk}=${v[subk]}"
                         }
@@ -1268,7 +1268,7 @@ def parallelStages = prepareDynamatrix(
             if (buildLabelsAgentsBuild.size() > 0) {
                 DynamatrixSingleBuildConfig dsbc = new DynamatrixSingleBuildConfig(this.script)
                 def tmp = buildLabelsAgentsBuild.clone()
-                tmp.keySet().each() {ble ->
+                tmp.keySet().each() {String ble ->
                     dsbc.buildLabelExpression = ble
                     dsbc.buildLabelSet = buildLabelsAgentsBuild[ble]
                     if (dsbc.matchesConstraints(dynacfgBuild.excludeCombos)) {
@@ -1283,7 +1283,7 @@ def parallelStages = prepareDynamatrix(
             if (virtualAxes.size() > 0) {
                 DynamatrixSingleBuildConfig dsbc = new DynamatrixSingleBuildConfig(this.script)
                 def tmp = virtualAxes.clone()
-                tmp.each() {virtualLabelSet ->
+                tmp.each() {Set virtualLabelSet ->
                     dsbc.virtualLabelSet = virtualLabelSet
                     if (dsbc.matchesConstraints(dynacfgBuild.excludeCombos)) {
                         virtualAxes.remove(virtualLabelSet)
@@ -1297,7 +1297,7 @@ def parallelStages = prepareDynamatrix(
             if (dynacfgBuild.dynamatrixAxesCommonEnv.size() > 0) {
                 DynamatrixSingleBuildConfig dsbc = new DynamatrixSingleBuildConfig(this.script)
                 def tmp = dynacfgBuild.dynamatrixAxesCommonEnv.clone()
-                tmp.each() {envvarSet ->
+                tmp.each() {Set envvarSet ->
                     dsbc.envvarSet = envvarSet
                     if (dsbc.matchesConstraints(dynacfgBuild.excludeCombos)) {
                         dynacfgBuild.dynamatrixAxesCommonEnv.remove(envvarSet)
@@ -1311,7 +1311,7 @@ def parallelStages = prepareDynamatrix(
             if (dynacfgBuild.dynamatrixAxesCommonOpts.size() > 0) {
                 DynamatrixSingleBuildConfig dsbc = new DynamatrixSingleBuildConfig(this.script)
                 def tmp = dynacfgBuild.dynamatrixAxesCommonOpts.clone()
-                tmp.each() {clioptSet ->
+                tmp.each() {Set clioptSet ->
                     dsbc.clioptSet = clioptSet
                     if (dsbc.matchesConstraints(dynacfgBuild.excludeCombos)) {
                         dynacfgBuild.dynamatrixAxesCommonOpts.remove(clioptSet)
@@ -1363,7 +1363,7 @@ def parallelStages = prepareDynamatrix(
         def removedTotal = 0
         def allowedToFailTotal = 0
         Set<DynamatrixSingleBuildConfig> dsbcSet = []
-        buildLabelsAgentsBuild.keySet().each() {ble ->
+        buildLabelsAgentsBuild.keySet().each() {String ble ->
             // We can generate numerous build configs below that
             // would all require this (or identical) agent by its
             // build label expression, so prepare the shared part:
@@ -1385,7 +1385,7 @@ def parallelStages = prepareDynamatrix(
             // Roll the snowball, let it grow!
             if (dynacfgBuild.dynamatrixAxesCommonOpts.size() > 0) {
                 Set<DynamatrixSingleBuildConfig> dsbcBleSetTmp = []
-                dynacfgBuild.dynamatrixAxesCommonOpts.each() {clioptSet ->
+                dynacfgBuild.dynamatrixAxesCommonOpts.each() {Set clioptSet ->
                     DynamatrixSingleBuildConfig dsbcBleTmp = dsbcBle.clone()
                     dsbcBleTmp.clioptSet = clioptSet
                     dsbcBleSetTmp += dsbcBleTmp
@@ -1397,7 +1397,7 @@ def parallelStages = prepareDynamatrix(
 
             if (dynacfgBuild.dynamatrixAxesCommonEnv.size() > 0) {
                 Set<DynamatrixSingleBuildConfig> dsbcBleSetTmp = []
-                dynacfgBuild.dynamatrixAxesCommonEnv.each() {envvarSet ->
+                dynacfgBuild.dynamatrixAxesCommonEnv.each() {Set envvarSet ->
                     dsbcBleSet.each() {DynamatrixSingleBuildConfig tmp ->
                         DynamatrixSingleBuildConfig dsbcBleTmp = tmp.clone()
                         dsbcBleTmp.envvarSet = envvarSet
@@ -1410,7 +1410,7 @@ def parallelStages = prepareDynamatrix(
             if (virtualAxes.size() > 0) {
                 Set<DynamatrixSingleBuildConfig> dsbcBleSetTmp = []
                 if (debugTrace) this.script.println "[DEBUG] generateBuildConfigSet(): COMBINING: virtualAxes: ${Utils.castString(virtualAxes)}\nvs. dsbcBleSet: ${dsbcBleSet}"
-                virtualAxes.each() {virtualLabelSet ->
+                virtualAxes.each() {Set virtualLabelSet ->
                     //if (debugTrace) this.script.println "[DEBUG] generateBuildConfigSet(): checking virtualLabelSet: ${Utils.castString(virtualLabelSet)}"
                     dsbcBleSet.each() {DynamatrixSingleBuildConfig tmp ->
                         DynamatrixSingleBuildConfig dsbcBleTmp = tmp.clone()
@@ -1565,12 +1565,12 @@ def parallelStages = prepareDynamatrix(
      * Helper for {@link #generateBuild} method to not repeat the
      * same code structure in different handled situations.
      */
-    //private Closure generatedBuildWrapperLayer2 (String stageName, DynamatrixSingleBuildConfig dsbc, Closure body = null) {
-    private Closure generatedBuildWrapperLayer2 (stageName, dsbc, body = null) {
+    private Closure generatedBuildWrapperLayer2 (String stageName, DynamatrixSingleBuildConfig dsbc, Closure body = null) {
+    //private Closure generatedBuildWrapperLayer2 (stageName, dsbc, body = null) {
         def debugTrace = this.shouldDebugTrace()
 
         // For delegation to closure and beyond
-        script = this.script
+        def script = this.script
         body.delegate.script = this.script
 
         // echo's below are not debug-decorated, in these cases they are the payload
@@ -1644,8 +1644,8 @@ def parallelStages = prepareDynamatrix(
      * may be tweaked for some build scenario, so we pass
      * the string around.
      */
-    //private Closure generatedBuildWrapperLayer1 (String stageName, DynamatrixSingleBuildConfig dsbc, Closure body = null) {
-    private Closure generatedBuildWrapperLayer1 (stageName, dsbc, body = null) {
+    private Closure generatedBuildWrapperLayer1 (String stageName, DynamatrixSingleBuildConfig dsbc, Closure body = null) {
+    //private Closure generatedBuildWrapperLayer1 (stageName, dsbc, body = null) {
 //CLS//
         return { ->
 //            script.stage(stageName) {
@@ -1694,7 +1694,8 @@ def parallelStages = prepareDynamatrix(
      * Helper which returns a Closure for optional build-log trace and
      * execution of the payload without a dedicated build agent.
      */
-    def generateParstageWithoutAgent(script, dsbc, stageName, sbName, payload) {
+    def generateParstageWithoutAgent (def script, DynamatrixSingleBuildConfig dsbc, String stageName, String sbName, Closure payload) {
+    // def generateParstageWithoutAgent(script, dsbc, stageName, sbName, payload) {
         return { ->
             if (dsbc.enableDebugTrace) script.echo "Not requesting any node for stage '${stageName}'" + sbName
             payload()
@@ -1706,7 +1707,8 @@ def parallelStages = prepareDynamatrix(
      * execution of the payload on a dedicated build agent selected by
      * the {@code dsbc.buildLabelExpression}.
      */
-    def generateParstageWithAgentBLE(script, dsbc, stageName, sbName, payload) {
+    def generateParstageWithAgentBLE(def script, DynamatrixSingleBuildConfig dsbc, String stageName, String sbName, Closure payload) {
+    // def generateParstageWithAgentBLE(script, dsbc, stageName, sbName, payload) {
         return { ->
             if (dsbc.enableDebugTrace) script.echo "Requesting a node by label expression '${dsbc.buildLabelExpression}' for stage '${stageName}'" + sbName
             script.node (dsbc.buildLabelExpression) {
@@ -1721,7 +1723,8 @@ def parallelStages = prepareDynamatrix(
      * execution of the payload on a dedicated build agent selected as
      * "any" currently available one.
      */
-    def generateParstageWithAgentAnon(script, dsbc, stageName, sbName, payload) {
+    def generateParstageWithAgentAnon(script, DynamatrixSingleBuildConfigdsbc, String stageName, String sbName, Closure payload) {
+    // def generateParstageWithAgentAnon(script, dsbc, stageName, sbName, payload) {
         return { ->
             if (dsbc.enableDebugTrace) script.echo "Requesting any node for stage '${stageName}'" + sbName
             script.node {
@@ -1892,7 +1895,7 @@ def parallelStages = prepareDynamatrix(
                 def payloadTmp = payload
 
                 payload = {
-                    def Throwable caught = null
+                    Throwable caught = null
                     try {
                         script.timeout (dsbc.stageTimeoutSettings) {
                             payloadTmp
@@ -2433,10 +2436,9 @@ def parallelStages = prepareDynamatrix(
         } else {
             // Scope the Map for sake of CPS conversions where we don't want them
             def parallelStages_map = [:]
-            parallelStages.each {tup -> parallelStages_map[tup[0]] = tup[1] }
+            parallelStages.each {def tup -> parallelStages_map[tup[0]] = tup[1] }
             return parallelStages_map
         }
     } // generateBuild()
 
 }
-

--- a/src/org/nut/dynamatrix/DynamatrixConfig.groovy
+++ b/src/org/nut/dynamatrix/DynamatrixConfig.groovy
@@ -606,7 +606,7 @@ def parallelStages = prepareDynamatrix(
 
         String errs = ""
         if (dynacfgOrig.size() > 0) {
-            dynacfgOrig.keySet().each() {k ->
+            dynacfgOrig.keySet().each() {def k ->
                 if (debugTrace) this.script.println("[DEBUG] DynamatrixConfig(Map): checking dynacfgOrig[${k}] = ${Utils.castString(dynacfgOrig[k])}")
 
                 if (k.equals("mergeMode")) return // continue
@@ -661,7 +661,7 @@ def parallelStages = prepareDynamatrix(
      * need re-initialization by Dynamatrix.prepareDynamatrix(),
      * then let these config point be re-defined (in that reinit).
      */
-    def clearNeedsPrepareDynamatrixClone(dc = [:]) {
+    def clearNeedsPrepareDynamatrixClone(Map dc = [:]) {
         if (dc?.commonLabelExpr)
             this.commonLabelExpr = null
         if (dc?.dynamatrixAxesLabels)
@@ -725,8 +725,8 @@ def parallelStages = prepareDynamatrix(
 
         // TODO: Use StringBuilder
         if (Utils.isListNotEmpty(this.requiredNodelabels)) {
-            def le = null
-            this.requiredNodelabels.each() { l ->
+            String le = null
+            this.requiredNodelabels.each() {String l ->
                 if (le == null) {
                     le = l
                 } else {
@@ -739,8 +739,8 @@ def parallelStages = prepareDynamatrix(
 
         // TODO: Use StringBuilder
         if (Utils.isListNotEmpty(this.excludedNodelabels)) {
-            def le = null
-            this.excludedNodelabels.each() { l ->
+            String le = null
+            this.excludedNodelabels.each() {String l ->
                 if (le == null) {
                     le = "!" + l
                 } else {

--- a/src/org/nut/dynamatrix/DynamatrixConfig.groovy
+++ b/src/org/nut/dynamatrix/DynamatrixConfig.groovy
@@ -3,7 +3,8 @@ package org.nut.dynamatrix;
 import org.nut.dynamatrix.Utils;
 import org.nut.dynamatrix.dynamatrixGlobalState;
 
-/* This class intends to represent one build request configuration
+/**
+ * This class intends to represent one build request configuration
  * An instance of it can be passed as the set of arguments for the
  * customized run Dynamatrix routines, while some defaults can be
  * applied so needed fields are all "defined" when we look at them.
@@ -14,164 +15,261 @@ class DynamatrixConfig implements Cloneable {
     public boolean enableDebugTrace = dynamatrixGlobalState.enableDebugTrace
     public boolean enableDebugErrors = dynamatrixGlobalState.enableDebugErrors
 
-    // Define fields to satisfy the build example below
-    //    commonLabelExpr: 'nut-builder',
+    /**
+     * Define fields to satisfy the build example in docs:
+     *    <pre>commonLabelExpr: 'nut-builder',</pre>
+     */
     public String commonLabelExpr = null
 
     // TODO: Abstract the compiler/tool related tunables and perhaps methods
-    // into a separate class and implement variants as its subclasses.
+    //  into a separate class and implement variants as its subclasses.
 
-    //    compilerType: 'C',
+    /**
+     * Define fields to satisfy the build example in docs:
+     *    <pre>compilerType: 'C',</pre>
+     */
     public CompilerTypes compilerType = null
 
-    // This represents the axis (originating from labels declared by build
-    // nodes) which defines the different compiler families. It can help
-    // to e.g. set specific flags not supported by other compilers:
-    //    compilerLabel: 'COMPILER',
+    /** This represents the axis (originating from labels declared by build
+     * nodes) which defines the different compiler families. It can help
+     * to e.g. set specific flags not supported by other compilers:
+     *    <pre>compilerLabel: 'COMPILER',</pre>
+     */
     public String compilerLabel = null
 
-    // envvars that would be exported to point to a particular compiler
-    // implementation and version for one build scenario:
-    //    compilerTools: ['CC', 'CXX', 'CPP'],
+    /** envvars that would be exported to point to a particular compiler
+     * implementation and version for one build scenario:
+     *    <pre>compilerTools: ['CC', 'CXX', 'CPP'],</pre>
+     */
     public Set<String> compilerTools = []
 
-    // Each of these labels can be String, GString or Pattern object
-    // to match labels (named as key=value pairs) of build agents:
-    //    dynamatrixAxesLabels: ['OS', '${COMPILER}VER', 'ARCH'],
+    /** Each of these labels can be String, GString or Pattern object
+     * to match labels (named as key=value pairs) of build agents:
+     *    <pre>dynamatrixAxesLabels: ['OS', '${COMPILER}VER', 'ARCH'],</pre>
+     */
     public Set dynamatrixAxesLabels = []
 
     // TODO: Need a way to specify that we only want some extreme value
-    // but not the whole range, somehow specifiable per-system (e.g. to
-    // say that we want the newest GCCVER (and/or CLANGVER) to build a
-    // docs-only scenario where we do not benefit from iterating all
-    // compilers available, and yet do not care which specific version
-    // numbers our particular agents serve so don't specify them in a
-    // dynamatrix specification).
+    //  but not the whole range, somehow specifiable per-system (e.g. to
+    //  say that we want the newest GCCVER (and/or CLANGVER) to build a
+    //  docs-only scenario where we do not benefit from iterating all
+    //  compilers available, and yet do not care which specific version
+    //  numbers our particular agents serve so don't specify them in a
+    //  dynamatrix specification).
+
     // TODO: Similarly, want a way to specify that we only want to run
-    // some dynamatrix scenario once (at all, or per OS type etc.) --
-    // e.g. to test buildability of complete documentation set or some
-    // distcheck target; this is more about tools on agent and recipes
-    // in the Makefiles of the project than about an exhaustive matrix.
+    //  some dynamatrix scenario once (at all, or per OS type etc.) --
+    //  e.g. to test buildability of complete documentation set or some
+    //  distcheck target; this is more about tools on agent and recipes
+    //  in the Makefiles of the project than about an exhaustive matrix.
 
     // TODO: Need a way to specify optional labels, so that nodes which
-    // do not declare any value (e.g. do not state which ARCH(es) they
-    // support) can still be used for some unique build combos ("...but
-    // that is our only system that runs SUPERCCVER=123").
+    //  do not declare any value (e.g. do not state which ARCH(es) they
+    //  support) can still be used for some unique build combos ("...but
+    //  that is our only system that runs SUPERCCVER=123").
 
-    // Let the caller specify additional dimensions to the matrix which
-    // are not based on values of labels declared by current workers, as
-    // a map of labels and a set of their values. For example, a matrix
-    // for C/C++ builds can declare several standards to check:
-    //    dynamatrixAxesVirtualLabelsMap: [
-    //      'CSTDVERSION': ['89', '99', '03', '11', '14', '17', '2x'],
-    //      'CSTDVARIANT': ['c', 'gnu'],
-    //    ]
-    // Like other (label) values, these would be ultimately mixed as a
-    // cartesian product with values from combos provided into the closure
-    // doing the build, subject to "excludeCombos" and "allowedFailure"
-    // detailed below, but they should not end up in label expressions
-    // to match the build agents by Jenkins.
-    // Parsing of dynamatrixAxesVirtualLabelsMap also supports a special
-    // syntax to process sub-maps of linked values that should be together:
-    // for this mode, the key string in dynamatrixAxesVirtualLabelsMap
-    // should contain a verbatim sub-string '${KEY}' which would then be
-    // replaced by key of the sub-map value or by 'DEFAULT' if the item
-    // is not a map; note that like other labels, these would be exported
-    // to shell so compatible names are recommended (e.g. 'cxx' not 'c++'):
-    //    dynamatrixAxesVirtualLabelsMap: [
-    //      'CSTDVERSION_${KEY}': [ ['c': '89', 'cxx': '98'], ['c': '99', 'cxx': '98'], ['c': '17', 'cxx: '17'] ],
-    //      'CSTDVARIANT': ['c', 'gnu'],
-    //    ]
-    // WARNING: main-map keys that do not contain a '${KEY}' (or have
-    // value types that are not a sub-map) would be assigned via toString()
-    // and can lead to bogus results like `CSTDVERSION="[c:89, cxx:98]"`.
+    /** Let the caller specify additional dimensions to the matrix which
+     * are not based on values of labels declared by current workers, as
+     * a map of labels and a set of their values. For example, a matrix
+     * for C/C++ builds can declare several standards to check:
+     * <pre>
+     *    dynamatrixAxesVirtualLabelsMap: [
+     *      'CSTDVERSION': ['89', '99', '03', '11', '14', '17', '2x'],
+     *      'CSTDVARIANT': ['c', 'gnu'],
+     *    ]
+     * </pre>
+     *
+     * <p>Like other (label) values, these would be ultimately mixed as a
+     * cartesian product with values from combos provided into the closure
+     * doing the build, subject to "excludeCombos" and "allowedFailure"
+     * detailed below, but they should not end up in label expressions
+     * to match the build agents by Jenkins.</p>
+     *
+     * Parsing of dynamatrixAxesVirtualLabelsMap also supports a special
+     * syntax to process sub-maps of linked values that should be together:
+     * for this mode, the key string in dynamatrixAxesVirtualLabelsMap
+     * should contain a verbatim sub-string '${KEY}' which would then be
+     * replaced by key of the sub-map value or by 'DEFAULT' if the item
+     * is not a map; note that like other labels, these would be exported
+     * to shell so compatible names are recommended (e.g. 'cxx' not 'c++'):
+     * <pre>
+     *    dynamatrixAxesVirtualLabelsMap: [
+     *      'CSTDVERSION_${KEY}': [ ['c': '89', 'cxx': '98'], ['c': '99', 'cxx': '98'], ['c': '17', 'cxx: '17'] ],
+     *      'CSTDVARIANT': ['c', 'gnu'],
+     *    ]
+     * </pre>
+     *
+     * WARNING: main-map keys that do not contain a '${KEY}' (or have
+     * value types that are not a sub-map) would be assigned via toString()
+     * and can lead to bogus results like `CSTDVERSION="[c:89, cxx:98]"`.
+     *
+     * @see #dynamatrixAxesCommonEnvCartesian
+     */
     public Map dynamatrixAxesVirtualLabelsMap = [:]
 
-    // Set of (Sets of envvars to export) - the resulting build matrix
-    // picks one of these at a time for otherwise same conditions made
-    // from other influences. This example defines two build variants:
-    //    dynamatrixAxesCommonEnv: [['LANG=C', 'TZ=UTC'], ['LANG=ru_RU', 'SHELL=ksh']],
+    /**
+     * Set of (Sets of envvars to export) - the resulting build matrix
+     * picks one of these at a time for otherwise same conditions made
+     * from other influences. This example defines two build variants:
+     * <pre>
+     *    dynamatrixAxesCommonEnv: [['LANG=C', 'TZ=UTC'], ['LANG=ru_RU', 'SHELL=ksh']],
+     * </pre>
+     */
     public Set<Set> dynamatrixAxesCommonEnv = []
-    // Same goal as above, but builds would get a Cartesian multiplication
-    // of the variants listed in the sub-sets, e.g. this example:
-    //    dynamatrixAxesCommonEnvCartesian: [['LANG=C', 'LANG=ru_RU'], ['TZ=UTC', 'TZ=CET']]
-    // ...should produce four build variants that would feed into the
-    // dynamatrixAxesCommonEnv use-case, namely:
-    //    [['LANG=C','TZ=UTC'], ['LANG=ru_RU','TZ=UTC'], ['LANG=C','TZ=CET'], ['LANG=ru_RU','TZ=CET']]
-    // NOTE: third-layer objects (e.g. meaningful sets not strings) should
-    // get plugged into the result "as is" and can help group related options
-    // without "internal conflict", e.g.:
-    //    dynamatrixAxesCommonEnvCartesian: [[ ['LANG=C','LC_ALL=C'], 'LANG=ru_RU'], ['TZ=UTC', 'TZ=CET']]
-    // should yield such four build variants:
-    //    [['LANG=C','LC_ALL=C','TZ=UTC'], ['LANG=ru_RU','TZ=UTC'], ['LANG=C','LC_ALL=C','TZ=CET'], ['LANG=ru_RU','TZ=CET']]
+
+    /**
+     * Same goal as in {@link #dynamatrixAxesCommonEnv}, but builds would
+     * get a Cartesian multiplication of the variants listed in the sub-sets,
+     * e.g. this example:
+     * <pre>
+     *    dynamatrixAxesCommonEnvCartesian: [
+     *       ['LANG=C', 'LANG=ru_RU'],
+     *       ['TZ=UTC', 'TZ=CET']
+     *    ]
+     * </pre>
+     * ...should produce four build variants that would feed into the
+     * dynamatrixAxesCommonEnv use-case, namely:
+     * <pre>
+     *    [['LANG=C','TZ=UTC'],
+     *     ['LANG=ru_RU','TZ=UTC'],
+     *     ['LANG=C','TZ=CET'],
+     *     ['LANG=ru_RU','TZ=CET']]
+     * </pre>
+     *
+     * NOTE: third-layer objects (e.g. meaningful sets not strings) should
+     * get plugged into the result "as is" and can help group related options
+     * without "internal conflict", e.g.:
+     * <pre>
+     *    dynamatrixAxesCommonEnvCartesian: [
+     *       [ ['LANG=C','LC_ALL=C'], 'LANG=ru_RU'],
+     *       ['TZ=UTC', 'TZ=CET']
+     *    ]
+     * </pre>
+     * should yield such four build variants:
+     * <pre>
+     *    [['LANG=C','LC_ALL=C','TZ=UTC'],
+     *     ['LANG=ru_RU','TZ=UTC'],
+     *     ['LANG=C','LC_ALL=C','TZ=CET'],
+     *     ['LANG=ru_RU','TZ=CET']]
+     * </pre>
+     */
     public Set<Set> dynamatrixAxesCommonEnvCartesian = []
 
-    // Set of (Sets of args to build tool into its command-line options).
-    // Similar approach as above:
-    // This defines four builds, two of these would set two build options
-    // each (for trying two C/C++ standards), and the other two would set
-    // different build bitness (with other default configuration settings):
-    //    dynamatrixAxesCommonOpts: [
-    //        ["CFLAGS=-stdc=gnu99", "CXXFLAGS=-stdcxx=gnu++99"],
-    //        ["CFLAGS=-stdc=c89", "CXXFLAGS=-stdcxx=c++89"],
-    //        ['-m32'], ['-m64'] ]
+    /**
+     * Set of (Sets of args to build tool into its command-line options).
+     * Similar approach as in {@link #dynamatrixAxesCommonEnv}:<br/>
+     * This defines four builds, two of these would set two build options
+     * each (for trying two C/C++ standards), and the other two would set
+     * different build bitness (with other default configuration settings):
+     * <pre>
+     *    dynamatrixAxesCommonOpts: [
+     *        ["CFLAGS=-stdc=gnu99", "CXXFLAGS=-stdcxx=gnu++99"],
+     *        ["CFLAGS=-stdc=c89", "CXXFLAGS=-stdcxx=c++89"],
+     *        ['-m32'], ['-m64'] ]
+     * </pre>
+     * @see #dynamatrixAxesCommonOptsCartesian
+     * @see #dynamatrixAxesCommonEnv
+     */
     public Set<Set> dynamatrixAxesCommonOpts = []
-    // ...and this (also with third-layer support) example:
-    //    dynamatrixAxesCommonOptsCartesian: [
-    //        [ ["CFLAGS=-stdc=gnu99", "CXXFLAGS=-stdcxx=g++99"],
-    //          ["CFLAGS=-stdc=c89", "CXXFLAGS=-stdcxx=c++89"]     ],
-    //        ['-m32', '-m64'] ]
-    // has two second-layer sets: one varies (grouped sets of) C/C++
-    // standards, another varies bitnesses. The result is also to try
-    // four build scenarios, but these four would run each combination
-    // of language revision and bitness, compactly worded like this:
-    //    [ [gnu99,m32], [c89,m32], [gnu99,m64], [c89,m64] ]
-    // WARNING: This is an illustrative example, -mXX should belong inside
-    // the CFLAGS, CXXFLAGS and LDFLAGS values, so the closure doing some
-    // build in an ultimate shell command should take care of that.
+
+    /**
+     * Building up from {@link #dynamatrixAxesCommonOpts} and
+     * {@link #dynamatrixAxesCommonEnvCartesian} ideas...
+     * and this example (also with third-layer support):
+     * <pre>
+     *    dynamatrixAxesCommonOptsCartesian: [
+     *        [ ["CFLAGS=-stdc=gnu99", "CXXFLAGS=-stdcxx=g++99"],
+     *          ["CFLAGS=-stdc=c89", "CXXFLAGS=-stdcxx=c++89"] ],
+     *        ['-m32', '-m64']
+     *    ]
+     * </pre>
+     * has two second-layer sets: one varies (grouped sets of) C/C++
+     * standards, another varies bitnesses. The result is also to try
+     * four build scenarios, but these four would run each combination
+     * of language revision and bitness, compactly worded like this:
+     * <pre>
+     *    [ [gnu99,m32], [c89,m32], [gnu99,m64], [c89,m64] ]
+     * </pre>
+     * WARNING: This is an illustrative example, -mXX should belong inside
+     * the CFLAGS, CXXFLAGS and LDFLAGS values, so the closure doing some
+     * build in an ultimate shell command should take care of that.
+     */
     public Set<Set> dynamatrixAxesCommonOptsCartesian = []
 
-    // On top of combinations discovered from existing nodes, add the
-    // following combinations as required for a build. While these are
-    // not labels (values or even names) proclaimed by the running agents,
-    // in some Jenkins agent plugins the pressure to have requested type
-    // of workers can get them tailored to order and deployed:
-    //    dynamatrixRequiredLabelCombos: [["OS=bsd", "CLANG=12"]],
+    /**
+     * On top of combinations discovered from existing nodes, add the
+     * following combinations as required for a build. While these are
+     * not labels (values or even names) proclaimed by the running agents,
+     * in some Jenkins agent plugins the pressure to have requested type
+     * of workers can get them tailored to order and deployed:
+     * <pre>
+     *    dynamatrixRequiredLabelCombos: [["OS=bsd", "CLANG=12"]],
+     * </pre>
+     */
     public Set dynamatrixRequiredLabelCombos = []
 
-    // During a build, configure variants which match these optional
-    // conditions as something that may fail and not be fatal to the
-    // overall job - like experimental builds on platforms we know we
-    // do not yet support well, but already want to keep watch on:
-    //    allowedFailure: [[~/OS=.+/, ~/GCCVER=4\..+/], ['ARCH=armv7l'], [~/std.+=.+89/]],
+    /**
+     * During a build, configure variants which match these optional
+     * conditions as something that may fail and not be fatal to the
+     * overall job - like experimental builds on platforms we know we
+     * do not yet support well, but already want to keep a watch on:
+     * <pre>
+     *    allowedFailure: [
+     *       [~/OS=.+/, ~/GCCVER=4\..+/],
+     *       ['ARCH=armv7l'],
+     *       [~/std.+=.+89/]
+     *    ],
+     * </pre>
+     */
     public Set allowedFailure = []
 
-    // Flag to conserve resources of CI farm - only run the builds in
-    // the allowedFailure list then this flag is "true" (on demand),
-    // but otherwise (false) treat them as excludeCombos and do not
-    // run them at all - that's by default.
+    /**
+     * Flag to conserve resources of CI farm - only run the builds in the
+     * {@link #allowedFailure} list then this flag is {@code true}
+     * (i.e. on demand), but otherwise ({@code false}) treat them as
+     * {@link #excludeCombos} and do not run them at all - that's by default.
+     */
     public Boolean runAllowedFailure = false
 
-    // After defining a build matrix from combinations which did match
-    // various requirements, drop combinations we know would be doomed,
-    // like trying the latest modern revision of C++ on the 20 year old
-    // version of the compiler.
-    //    excludeCombos: [[~/OS=openindiana/, ~/CLANGVER=9/, ~/ARCH=x86/], [~/GCCVER=4\.[0-7]\..+/, ~/std.+=+(!?89|98|99|03)/], [~/GCCVER=4\.([8-9]|1[0-9]+)\..+/, ~/std.+=+(!?89|98|99|03|11)/]]
+    /**
+     * After defining a build matrix from combinations which did match
+     * various requirements, drop combinations we know would be doomed,
+     * like trying the latest modern revision of C++ on the 20 year old
+     * version of the compiler.
+     * <pre>
+     *    excludeCombos: [
+     *       [~/OS=openindiana/, ~/CLANGVER=9/, ~/ARCH=x86/],
+     *       [~/GCCVER=4\.[0-7]\..+/, ~/std.+=+(!?89|98|99|03)/],
+     *       [~/GCCVER=4\.([8-9]|1[0-9]+)\..+/, ~/std.+=+(!?89|98|99|03|11)/]
+     *    ]
+     * </pre>
+     */
     public Set excludeCombos = []
 
-    // Beside values that are permutated in the matrix combos, we can
-    // also use other labels declared by build agents to filter further.
-    // This differs from dynamatrixRequiredLabelCombos above which add
-    // combinations on top of filtered permutations and might cause some
-    // build agents to be deployed, etc. to fulfill that requirement.
-    // Here we *filter away* combos that would land to nodes that *have*
-    // labels which match any of excludedNodelabels, or that *do not have*
-    // labels which match all of requiredNodelabels.
+    /**
+     * Beside values that are permutated in the matrix combos, we can
+     * also use other labels declared by build agents to filter further.<br/>
+     *
+     * This differs from {@link #dynamatrixRequiredLabelCombos} which add
+     * combinations on top of filtered permutations and might cause some
+     * build agents to be deployed, etc. to fulfill that requirement.<br/>
+     *
+     * Here we *filter away* combos that would land to nodes that
+     * *have* labels which match any of {@link #excludedNodelabels}, or that
+     * *do not have* labels which match all of {@code requiredNodelabels}.<br/>
+     *
+     * @see #excludedNodelabels
+     */
     public Set requiredNodelabels = []
+    /** @see #requiredNodelabels */
     public Set excludedNodelabels = []
 
-    // Same as for timeout() step, e.g.
-    //    dsbc.stageTimeoutSettings = {time: 12, unit: "HOURS"}
+    /**
+     * Same values as for {@code timeout()} step, e.g.
+     * <pre>
+     *    dsbc.stageTimeoutSettings = {time: 12, unit: "HOURS"}
+     * </pre>
+     */
     public Map dsbcStageTimeoutSettings = [:]
 
     @NonCPS
@@ -264,7 +362,7 @@ def parallelStages = prepareDynamatrix(
         this.initDefault(defaultCfg)
     }
 
-    public boolean canEqual(java.lang.Object other) {
+    public boolean canEqual(Object other) {
         return other instanceof DynamatrixConfig
     }
 
@@ -279,8 +377,7 @@ def parallelStages = prepareDynamatrix(
         if (debugTrace) this.script.println("[DEBUG] DynamatrixConfig(String): called with defaultCfg = ${Utils.castString(defaultCfg)}")
 
         switch (defaultCfg) {
-            case null:
-            case '':
+            case [null, '']:
                 break;
 
             case ['C', 'C-all', 'CXX', 'CXX-all', 'C+CXX', 'C+CXX-all']:
@@ -559,10 +656,12 @@ def parallelStages = prepareDynamatrix(
         return true
     }
 
+    /**
+     * If the incoming configuration would rewrite some fields that
+     * need re-initialization by Dynamatrix.prepareDynamatrix(),
+     * then let these config point be re-defined (in that reinit).
+     */
     def clearNeedsPrepareDynamatrixClone(dc = [:]) {
-        // If the incoming configuration would rewrite some fields that
-        // need re-initialization by Dynamatrix.prepareDynamatrix(),
-        // then let these config point be re-defined (in that reinit).
         if (dc?.commonLabelExpr)
             this.commonLabelExpr = null
         if (dc?.dynamatrixAxesLabels)
@@ -574,10 +673,12 @@ def parallelStages = prepareDynamatrix(
         return this
     }
 
+    /*
+     * Our callers expect a few specific data constructs here:
+     * either a single string or pattern (that will be remade into
+     * a single-element array), or an array/list/set/... of such types
+     */
     public def sanitycheckDynamatrixAxesLabels() {
-        // Our callers expect a few specific data constructs here:
-        // either a single string or pattern (that will be remade into
-        // a single-element array), or an array/list/set/... of such types
         String errs = ""
         if (this.dynamatrixAxesLabels != null) {
             if (Utils.isList(this.dynamatrixAxesLabels)) {
@@ -622,6 +723,7 @@ def parallelStages = prepareDynamatrix(
         def debugErrors = this.shouldDebugErrors()
         def debugTrace = this.shouldDebugTrace()
 
+        // TODO: Use StringBuilder
         if (Utils.isListNotEmpty(this.requiredNodelabels)) {
             def le = null
             this.requiredNodelabels.each() { l ->
@@ -635,6 +737,7 @@ def parallelStages = prepareDynamatrix(
             commonLabelExpr += " && (${le})"
         }
 
+        // TODO: Use StringBuilder
         if (Utils.isListNotEmpty(this.excludedNodelabels)) {
             def le = null
             this.excludedNodelabels.each() { l ->

--- a/src/org/nut/dynamatrix/DynamatrixSingleBuildConfig.groovy
+++ b/src/org/nut/dynamatrix/DynamatrixSingleBuildConfig.groovy
@@ -123,7 +123,7 @@ class DynamatrixSingleBuildConfig implements Cloneable {
      *   "enableDebugTrace", "enableDebugTraceFailures", "enableDebugErrors",
      *   "isExcluded", "isAllowedFailure"
      */
-    public boolean equals(java.lang.Object other) {
+    public boolean equals(Object other) {
         if (other == null) return false
         if (this.is(other)) return true
         if (!(other instanceof DynamatrixSingleBuildConfig)) return false
@@ -146,7 +146,7 @@ class DynamatrixSingleBuildConfig implements Cloneable {
         return true
     }
 
-    public boolean canEqual(java.lang.Object other) {
+    public boolean canEqual(Object other) {
         return other instanceof DynamatrixSingleBuildConfig
     }
 
@@ -550,7 +550,7 @@ class DynamatrixSingleBuildConfig implements Cloneable {
         // How many constraint hits did we score?
         def hits = 0
         def crit = 0
-        combo.each() {regexConstraint ->
+        combo.each() {def regexConstraint ->
             // Currently we only support regex matches here
             if (!Utils.isRegex(regexConstraint)) {
                 if (debugErrors) this.script.println ("[ERROR] matchesConstraintsCombo(): invalid input item type, skipped: ${Utils.castString(regexConstraint)}")
@@ -560,7 +560,7 @@ class DynamatrixSingleBuildConfig implements Cloneable {
 
             boolean hadHit = false
 
-            buildLabelSet.find {label ->
+            buildLabelSet.find {def label ->
                 if (label =~ regexConstraint) {
                     if (debugTrace) this.script.println ("[DEBUG] matchesConstraintsCombo(): buildLabelSet for ${Utils.castString(this)} matched ${Utils.castString(label)} - hit with ${regexConstraint}")
                     hadHit = true
@@ -570,7 +570,7 @@ class DynamatrixSingleBuildConfig implements Cloneable {
             }
 
             if (!hadHit) {
-                virtualLabelSet.find {label ->
+                virtualLabelSet.find {def label ->
                     if (label =~ regexConstraint) {
                         if (debugTrace) this.script.println ("[DEBUG] matchesConstraintsCombo(): virtualLabelSet for ${Utils.castString(this)} matched ${Utils.castString(label)} - hit with ${regexConstraint}")
                         hadHit = true
@@ -581,7 +581,7 @@ class DynamatrixSingleBuildConfig implements Cloneable {
             }
 
             if (!hadHit) {
-                 envvarSet.find {envvarval ->
+                 envvarSet.find {def envvarval ->
                     if (envvarval =~ regexConstraint) {
                         if (debugTrace) this.script.println ("[DEBUG] matchesConstraintsCombo(): envvarSet for ${Utils.castString(this)} matched ${Utils.castString(envvarval)} - hit with ${regexConstraint}")
                         hadHit = true
@@ -592,7 +592,7 @@ class DynamatrixSingleBuildConfig implements Cloneable {
             }
 
             if (!hadHit) {
-                clioptSet.find {cliopt ->
+                clioptSet.find {def cliopt ->
                     if (cliopt =~ regexConstraint) {
                         if (debugTrace) this.script.println ("[DEBUG] matchesConstraintsCombo(): clioptSet for ${Utils.castString(this)} matched ${Utils.castString(cliopt)} - hit with ${regexConstraint}")
                         hadHit = true
@@ -640,7 +640,7 @@ class DynamatrixSingleBuildConfig implements Cloneable {
             return false
         }
 
-        boolean res = combos.any {combo ->
+        boolean res = combos.any {def combo ->
             // No combo - no hit, extracted from matchesConstraintsCombo() to log more error details2
             if (Utils.isListNotEmpty(combo)) {
                 if (this.matchesConstraintsCombo(combo)) {

--- a/src/org/nut/dynamatrix/DynamatrixSingleBuildConfig.groovy
+++ b/src/org/nut/dynamatrix/DynamatrixSingleBuildConfig.groovy
@@ -6,7 +6,8 @@ import org.nut.dynamatrix.Utils;
 import org.nut.dynamatrix.Dynamatrix;
 import org.nut.dynamatrix.dynamatrixGlobalState;
 
-/* This class intends to represent one single build configuration
+/**
+ * This class intends to represent one single build configuration
  * with its agent label, further "virtual labels", env, opts and
  * other matrix-provided tunables derived from DynamatrixConfig
  * and Dynamatrix class field values.
@@ -19,67 +20,92 @@ class DynamatrixSingleBuildConfig implements Cloneable {
     public boolean enableDebugTraceFailures = dynamatrixGlobalState.enableDebugTraceFailures
     public boolean enableDebugErrors = dynamatrixGlobalState.enableDebugErrors
 
-    // By default, we wipe workspaces after a build
+    /** By default, we wipe workspaces after a build */
     public boolean keepWs = false
 
-    // Most of our builds require a build agent, usually one with
-    // specific capabilities as selected by label expression below,
-    // to run some programs in that OS. For generality's sake, there
-    // is a case for no-node mode, but that may only call pipeline
-    // steps (to schedule a build, maybe analyze, etc.)
+    /**
+     * Most of our builds require a build agent, usually one with
+     * specific capabilities as selected by label expression below,
+     * to run some programs in that OS. For generality's sake, there
+     * is a case for no-node mode, but that may only call pipeline
+     * steps (to schedule a build, maybe analyze, etc.)
+     */
     public Boolean requiresBuildNode = true
 
-    // The `expr` requested in `agent { label 'expr' }` for the
-    // generated build stage, originates from capabilities declared
-    // by build nodes or those explicitly requested by caller
+    /**
+     * The {@code `expr`} part requested in {@code `agent {label 'expr'}`}
+     * for the generated build stage, originates from capabilities declared
+     * by build nodes or those explicitly requested by caller.
+     */
     public String buildLabelExpression
 
-    // Original set of requested labels for the agent needed for
-    // this particular build, which can include usual labels like
-    // "ARCH=armv7l" and composite labels, which are useful for
-    // grouped values like "COMPILER=GCC GCCVER=1.2.3". Can be
-    // interpreted by the actual building closure (e.g. to
-    // generate options for configure script), such as converting
-    // `ARCH_BITS=64` into a `CFLAGS="$CLFAGS -m32"` addition:
+    /**
+     * Original set of requested labels for the agent needed for
+     * this particular build, which can include usual labels like
+     * {@code "ARCH=armv7l"} and composite labels, which are useful
+     * for grouped values like {@code "COMPILER=GCC GCCVER=1.2.3"}.
+     * Can be interpreted by the actual building closure (e.g. to
+     * generate options for configure script), such as converting
+     * {@code ARCH_BITS=64}" into a {@code CFLAGS="$CLFAGS -m32"}
+     * addition.
+     */
     public Set buildLabelSet
 
-    // Additional variation from the caller, such as revision of
-    // C/C++ standard to use for this particular run. Interpreted
-    // by the actual building closure (e.g. to generate options
-    // for configure script).
-    // Provided as a set of Strings with key=value pairs like:
-    //   ["CSTDVERSION=17", "CSTDVARIANT=gnu"]
-    // or
-    //   ["CSTDVERSION_c=11", "CSTDVERSION_cxx=14", "CSTDVARIANT=c"]
+    /**
+     * Additional variation from the caller, such as revision of
+     * C/C++ standard to use for this particular run. Interpreted
+     * by the actual building closure (e.g. to generate options
+     * for configure script).<br/>
+     *
+     * Provided as a set of Strings with key=value pairs like:
+     * <pre>
+     *   ["CSTDVERSION=17", "CSTDVARIANT=gnu"]
+     * </pre>
+     * or
+     * <pre>
+     *   ["CSTDVERSION_c=11", "CSTDVERSION_cxx=14", "CSTDVARIANT=c"]
+     * </pre>
+     */
     public Set virtualLabelSet
 
-    // Exported additional environment variables for this build, e.g.:
-    //   ["TZ=UTC", "LANG=C"]
+    /**
+     * Exported additional environment variables for this build, e.g.:
+     * <pre>
+     *   ["TZ=UTC", "LANG=C"]
+     * </pre>
+     */
     public Set envvarSet
 
-    // Additional command-line options for this build (as interpreted
-    // by the actual building closure - perhaps options for a configure
-    // script), e.g.:
-    //   ["CFLAGS=-stdc=gnu99", "CXXFLAGS=-stdcxx=g++99", "--without-docs"]
+    /**
+     * Additional command-line options for this build (as interpreted
+     * by the actual building closure - perhaps options for a configure
+     * script), e.g.:
+     * <pre>
+     *   ["CFLAGS=-stdc=gnu99", "CXXFLAGS=-stdcxx=g++99", "--without-docs"]
+     * </pre>
+     */
     public Set clioptSet
 
     public Boolean isExcluded
     public Boolean isAllowedFailure
 
-    // The build config can reference which dynamatrix group of build scenarios
-    // it would be tracked in, e.g. for failFastSafe support
+    /** The build config can reference which dynamatrix group of build scenarios
+     * it would be tracked in, e.g. for failFastSafe support */
     public Dynamatrix thisDynamatrix = null
 
-    // Help Dynamatrix accounting track intentional error()/unstable()/...
-    // exits from each build scenario. See also setWorstResult() below.
+    /* Help Dynamatrix accounting track intentional error()/unstable()/...
+     * exits from each build scenario. See also setWorstResult() below. */
     public Result dsbcResult = null
-    // If this is 'UNKNOWN', exception summary, etc. we may want to retry the
-    // build scenario which did not necessarily fail due to bad code
+    /** If this is 'UNKNOWN', exception summary, etc. we may want to retry the
+     * build scenario which did not necessarily fail due to bad code. */
     public String dsbcResultInterim = null
     public Integer startCount = 0
 
-    // Same as for timeout() step, e.g.
-    //    dsbc.stageTimeoutSettings = {time: 12, unit: "HOURS"}
+    /** Same units as for {@code timeout()} step, e.g.
+     * <pre>
+     *    dsbc.stageTimeoutSettings = {time: 12, unit: "HOURS"}
+     * </pre>
+     */
     public Map stageTimeoutSettings = [:]
 
     public DynamatrixSingleBuildConfig (script) {
@@ -89,7 +115,8 @@ class DynamatrixSingleBuildConfig implements Cloneable {
         this.enableDebugErrors = dynamatrixGlobalState.enableDebugErrors
     }
 
-    /* Compare class instances as equal in important fields (e.g. to dedup
+    /**
+     * Compare class instances as equal in important fields (e.g. to dedup
      * when adding again to Sets), despite possible variation in some
      * inconsequential fields:
      *   "script", "stageNameFunc",
@@ -197,9 +224,11 @@ class DynamatrixSingleBuildConfig implements Cloneable {
         return defaultStageName()
     }
 
+    /** e.g. {@code
+     * CSTDVERSION=99&&CSTDVARIANT=gnu&&COMPILER=clang&&CLANGVER=12 BUILD_TYPE=default-all-errors&&CFLAGS="-std=gnu99"&&CXXFLAGS="-std=gnu++99"&&CC=clang&&CXX=clang++  && TZ=UTC && LANG=C  -m32 --without-docs
+     * } */
     @NonCPS
     public String defaultStageName() {
-        // e.g. CSTDVERSION=99&&CSTDVARIANT=gnu&&COMPILER=clang&&CLANGVER=12 BUILD_TYPE=default-all-errors&&CFLAGS="-std=gnu99"&&CXXFLAGS="-std=gnu++99"&&CC=clang&&CXX=clang++  && TZ=UTC && LANG=C  -m32 --without-docs
 
         String sn = buildLabelExpression;
 
@@ -226,22 +255,25 @@ class DynamatrixSingleBuildConfig implements Cloneable {
         return sn;
     } // defaultStageName()
 
-    // One implementation that pipelines can assign:
-    //    dynamatrixGlobalState.stageNameFunc = DynamatrixSingleBuildConfig.&C_StageNameTagFunc
+    /**
+     * One implementation that pipelines can assign:
+     *    <pre>dynamatrixGlobalState.stageNameFunc = DynamatrixSingleBuildConfig.&C_StageNameTagFunc</pre>
+     */
     @NonCPS
     public static String C_StageNameTagFunc(DynamatrixSingleBuildConfig dsbc) {
         return 'MATRIX_TAG="' + DynamatrixSingleBuildConfig.C_StageNameTagValue(dsbc) + "\" && " + dsbc.defaultStageName()
     }
 
+    /**
+     * Return the set of (not-null and unique) values represented
+     * by whichever is populated of the: build agent labels, virtual
+     * labels, and envvars (but not the CLI options). Any composite
+     * labels are split into separate entries. Resulting set is not
+     * "guaranteed" to only contain key=value strings, but is expected
+     * to for practical purposes (consumer should check it if important)
+     */
     @NonCPS
     public Set getKVSet() {
-        /* Return the set of (not-null and unique) values represented
-         * by whichever is populated of the: build agent labels, virtual
-         * labels, and envvars (but not the CLI options). Any composite
-         * labels are split into separate entries. Resulting set is not
-         * "guaranteed" to only contain key=value strings, but is expected
-         * to for practical purposes (consumer should check it if important)
-         */
         // All labels of the world, unite!
         Set labelSet1 = (buildLabelSet + virtualLabelSet + envvarSet).flatten()
         labelSet1.remove(null)
@@ -265,20 +297,22 @@ class DynamatrixSingleBuildConfig implements Cloneable {
         return labelSet
     }
 
+    /**
+     * Return the map with (not-null and unique) key=values represented
+     * by whichever is populated of the: build agent labels, virtual
+     * labels, and envvars (but not the CLI options). Any composite
+     * labels are split into separate entries.<br/>
+     *
+     * The resulting Map is "guaranteed" to contain either key=value
+     * strings (with "key" string mapped to a "value" string), or
+     * "key" string mapped to null if the original label did not have
+     * an equality sign (and if storeNulls==true).<br/>
+     *
+     * Behavior is not defined if several of the original label sets
+     * assigned a (different) value to the same label key.
+     */
     @NonCPS
     public Map getKVMap(boolean storeNulls = false) {
-        /* Return the map with (not-null and unique) key=values represented
-         * by whichever is populated of the: build agent labels, virtual
-         * labels, and envvars (but not the CLI options). Any composite
-         * labels are split into separate entries.
-         * The resulting Map is "guaranteed" to contain either key=value
-         * strings (with "key" string mapped to a "value" string), or
-         * "key" string mapped to null if the original label did not have
-         * an equality sign (and if storeNulls==true).
-         * Behavior is not defined if several of the original label sets
-         * assigned a (different) value to the same label key.
-         */
-
         def debugErrors = this.shouldDebugErrors()
         def debugTrace = this.shouldDebugTrace()
 
@@ -321,12 +355,14 @@ class DynamatrixSingleBuildConfig implements Cloneable {
         return labelMap
     }
 
+    /**
+     * This routine might be used to construct actual "-std=..."
+     * argument for a compiler, or for the stage name tag below.
+     * The "useIsCXXforANSI" flag impacts whether we would emit
+     * "ansi++" string or not (makes tag friendlier, arg useless)
+     */
     @NonCPS
     public static String C_stdarg(String CSTDVARIANT, String CSTDVERSION, boolean isCXX = false, boolean useIsCXXforANSI = false) {
-        // This routine might be used to construct actual "-std=..."
-        // argument for a compiler, or for the stage name tag below.
-        // The "useIsCXXforANSI" flag impacts whether we would emit
-        // "ansi++" string or not (makes tag friendlier, arg useless)
         if (CSTDVERSION == "ansi") {
             if (isCXX && useIsCXXforANSI) {
                 // for tag
@@ -344,13 +380,14 @@ class DynamatrixSingleBuildConfig implements Cloneable {
         return sn
     }
 
+    /**
+     * Expected axis labels below match presets in DynamatrixConfig("C")
+     * and agent labels in examples.
+     * Parse {@code ARCH_BITS=64&&ARCH64=amd64&&COMPILER=CLANG&&CLANGVER=9&&OS_DISTRO=openindiana && BITS=64&&CSTDVARIANT=c&&CSTDVERSION=99 (isAllowedFailure)}
+     * => {@code NUT_MATRIX_TAG="c99-clang-openindiana-amd64-64bit(-warn|nowarn)(-mayFail)"}
+     */
     @NonCPS
     public static String C_StageNameTagValue(DynamatrixSingleBuildConfig dsbc) {
-        // Expected axis labels below match presets in DynamatrixConfig("C")
-        // and agent labels in examples.
-        // Parse ARCH_BITS=64&&ARCH64=amd64&&COMPILER=CLANG&&CLANGVER=9&&OS_DISTRO=openindiana && BITS=64&&CSTDVARIANT=c&&CSTDVERSION=99 (isAllowedFailure)
-        // => NUT_MATRIX_TAG="c99-clang-openindiana-amd64-64bit(-warn|nowarn)(-mayFail)"
-
         def labelMap = dsbc.getKVMap(false)
 
         String sn = ""
@@ -432,10 +469,14 @@ class DynamatrixSingleBuildConfig implements Cloneable {
         return sn
     } // C_StageNameTagValue(dsbc)
 
-    // One implementation that pipelines can assign:
-    //    dynamatrixGlobalState.stageNameFunc = DynamatrixSingleBuildConfig.&Shellcheck_StageNameTagFunc
-    //    dynamatrixGlobalState.stageNameFunc = DynamatrixSingleBuildConfig.&ShellcheckPlatform_StageNameTagFunc
-    // For platform, in which we can then group-test several shells:
+    /**
+     * One implementation that pipelines can assign:
+     * <pre>
+     *    dynamatrixGlobalState.stageNameFunc = DynamatrixSingleBuildConfig.&Shellcheck_StageNameTagFunc
+     *    dynamatrixGlobalState.stageNameFunc = DynamatrixSingleBuildConfig.&ShellcheckPlatform_StageNameTagFunc
+     * </pre>
+     * For a platform, in which we can then group-test several shells.
+     */
     @NonCPS
     public static String ShellcheckPlatform_StageNameTagFunc(DynamatrixSingleBuildConfig dsbc) {
         return 'MATRIX_TAG="' + DynamatrixSingleBuildConfig.ShellcheckPlatform_StageNameTagValue(dsbc) + '"'
@@ -456,7 +497,7 @@ class DynamatrixSingleBuildConfig implements Cloneable {
         return "${sn}shellcheck"
     }
 
-    // If a particular shell (or several) has been chosen for one test stage:
+    /** Use if a particular shell (or several) has been chosen for one test stage... */
     @NonCPS
     public static String Shellcheck_StageNameTagFunc(DynamatrixSingleBuildConfig dsbc) {
         return 'MATRIX_TAG="' + DynamatrixSingleBuildConfig.Shellcheck_StageNameTagValue(dsbc) + '"'
@@ -479,19 +520,24 @@ class DynamatrixSingleBuildConfig implements Cloneable {
         return matchesConstraintsCombo(new LinkedHashSet(combo))
     }
 
-    // Tight loop below, use primitive boolean type (not class) to be faster
+    /**
+     * Returns "true" if the current object hits all constraints
+     * in combo, which may be used for detecting (and possibly
+     * filtering away) excluded setups or allowed failures.<br/>
+     *
+     * The `combo` is one case of constraints, like this limitation
+     * example that early GCC versions (before 3.x) are deemed unfit
+     * for building C standard revisions other than C89/C90:
+     * <pre>
+     *   [~/GCCVER=[012]([^0-9.]|$|\.[0-9]+)/, ~/CSTDVERSION=(?!89|90)/]
+     * </pre>
+     * In this example, we have two regexes to check against all the
+     * labels, envvars and opts defined for this single build setup.<br/>
+     *
+     * NOTE: Tight loop below, use primitive boolean type (not class)
+     * to be faster.
+     */
     public boolean matchesConstraintsCombo (Set combo) {
-        /* Returns "true" if the current object hits all constraints
-         * in combo, which may be used for detecting (and possibly
-         * filtering away) excluded setups or allowed failures.
-         * The `combo` is one case of constraints, like this limitation
-         * example that early GCC versions (before 3.x) are deemed unfit
-         * for building C standard revisions other than C89/C90:
-         *   [~/GCCVER=[012]([^0-9.]|$|\.[0-9]+)/, ~/CSTDVERSION=(?!89|90)/]
-         * In this example, we have two regexes to check against all the
-         * labels, envvars and opts defined for this single build setup.
-         */
-
         def debugErrors = this.shouldDebugErrors()
         def debugTrace = this.shouldDebugTrace()
 
@@ -578,12 +624,13 @@ class DynamatrixSingleBuildConfig implements Cloneable {
         return matchesConstraints(new LinkedHashSet(combos))
     }
 
+    /**
+     * Call {@link #matchesConstraintsCombo}() for each combo in the
+     * larger set of combos (like {@link DynamatrixConfig#allowedFailure}[]
+     * or {@link DynamatrixConfig#excludeCombos}[] in the class
+     * {@link DynamatrixConfig}) to see if the current object hits any.
+     */
     public boolean matchesConstraints (Set combos) {
-        /* Call matchesConstraintsCombo() for each combo in the larger
-         * set of combos (like allowedFailure[] or excludeCombos[] in the
-         * class DynamatrixConfig) to see if the current object hits any.
-         */
-
         def debugErrors = this.shouldDebugErrors()
         def debugTrace = this.shouldDebugTrace()
 
@@ -618,4 +665,3 @@ class DynamatrixSingleBuildConfig implements Cloneable {
     } // matchesConstraints (Set)
 
 }
-

--- a/src/org/nut/dynamatrix/DynamatrixStash.groovy
+++ b/src/org/nut/dynamatrix/DynamatrixStash.groovy
@@ -175,7 +175,7 @@ class DynamatrixStash {
                 def seenClone = false
                 def seenSubmodules = false
                 // TODO? Just detect, do not change the iterated set?
-                scmParams.extensions.each() { extset ->
+                scmParams.extensions.each() {Map extset ->
                     if (extset.containsKey('$class')) {
                         switch (extset['$class']) {
                             case 'CloneOption':
@@ -618,7 +618,7 @@ echo "[DEBUG] Files in `pwd`: `find . -type f | wc -l` and all FS objects under:
             def lockName = script?.env?.DYNAMATRIX_REFREPO_WORKSPACE_LOCKNAME
             if (!Utils.isStringNotEmpty(lockName)) {
                 if (script?.env?.NODE_LABELS) {
-                    script.env.NODE_LABELS.split('[ \r\n\t]+').each() { KV ->
+                    script.env.NODE_LABELS.split('[ \r\n\t]+').each() {String KV ->
                         if (KV =~ /^DYNAMATRIX_REFREPO_WORKSPACE_LOCKNAME=.*$/) {
                             def key = null
                             def val = null
@@ -773,7 +773,7 @@ exit \$RET
         deleteWS(script)
         if (script?.env?.NODE_LABELS) {
             def useMethod = null
-            script.env.NODE_LABELS.split('[ \r\n\t]+').each() { KV ->
+            script.env.NODE_LABELS.split('[ \r\n\t]+').each() {String KV ->
                 //script.echo "[D] unstashCleanSrc(): Checking node label '${KV}'"
                 if (KV =~ /^DYNAMATRIX_UNSTASH_PREFERENCE=.*$/) {
                     def key = null

--- a/src/org/nut/dynamatrix/DynamatrixStash.groovy
+++ b/src/org/nut/dynamatrix/DynamatrixStash.groovy
@@ -8,60 +8,71 @@ import java.lang.reflect.Modifier;
 
 import hudson.plugins.git.extensions.GitSCMExtension;
 
-/* For Jenkins Swarm build agents that dial in to the controller,
+/**
+ * For Jenkins Swarm build agents that dial in to the controller,
  * which themselves may have or not have access to the SCM server,
  * we offer a way for the controller to push sources of the current
  * tested build as a stash. There is currently no way to cache it
  * however, so multiple builds landing on same agent suffer this
- * push many times (time, traffic, I/O involved).
+ * push many times (time, traffic, I/O involved).<br/>
  *
  * For agents that know they can access the original SCM server
  * (e.g. GitHub with public repos and generally available Internet),
  * it may be more optimal to tell them to just check out locally,
  * especially if optimizations like Git reference repository local
  * to that worker are involved. Such agents can declare this by
- * specifying a node label DYNAMATRIX_UNSTASH_PREFERENCE=... with
+ * specifying a node label {@code DYNAMATRIX_UNSTASH_PREFERENCE=...}
+ * with values like:
+ * <pre>
  *   ...=scm-ws(:stashName)
  *   ...=scm(:stashName)
  *   ...=unstash(:stashName)
- * with fallback handling in this order.
- * The optional ":stashName" suffix allows to limit the preference
- * to builds of a particular project which uses that string, e.g.
- * DYNAMATRIX_UNSTASH_PREFERENCE=scm:nut-ci-src
+ * </pre>
+ * with fallback handling in this order.<br/>
+ *
+ * The optional {@code ":stashName"} suffix allows to limit the
+ * preference to builds of a particular project which uses that
+ * string, e.g.
+ * <pre>
+ *    DYNAMATRIX_UNSTASH_PREFERENCE=scm:nut-ci-src
+ * </pre>
+ *
  * A node may define the default preference and ones customized for
- * the stashName(s), the latter would be preferred. A node should
- * not define two or more preferences for same stashName, behavior
- * would be undefined in that case.
+ * the {@code stashName}(s), the latter would be preferred. A node
+ * should not define two or more preferences for same {@code stashName},
+ * behavior would be undefined in that case.<br/>
  *
- * The original optional "scmbody" Closure used for stashCleanSrc()
+ * The original optional "scmbody" Closure used for {@link #stashCleanSrc}()
  * with that stashName would be replayed on the agent, if "scm" is
- * preferred.
+ * preferred.<br/>
  *
- * Also, if the current node running unstashCleanSrc() declares a
- * GIT_REFERENCE_REPO_DIR environment variable, its value would be
- * injected into GitSCM configuration for repo cloning operations.
- * For deployments running git-client-plugin with support for fanned
- * out refrepo like /some/path/${GIT_SUBMODULES}, that suffix string
- * '/${GIT_SUBMODULES}' should be verbatim in the expanded envvar:
+ * Also, if the current node running {@link #unstashCleanSrc}() declares a
+ * {@code GIT_REFERENCE_REPO_DIR} environment variable, its value would be
+ * injected into GitSCM configuration for repo cloning operations.<br/>
+ *
+ * NOTE: For deployments running git-client-plugin with support for fanned
+ * out refrepo like {@code /some/path/${GIT_SUBMODULES}}, that suffix string
+ * {@code '/${GIT_SUBMODULES}'} should be verbatim in the expanded envvar:
  *   https://issues.jenkins.io/browse/JENKINS-64383
  *   https://github.com/jenkinsci/git-client-plugin/pull/644
  *   https://github.com/jimklimov/git-refrepo-scripts
+ * <br/>
  *
- * TODO: the plugin itself does not define nor use the environment
- * variable GIT_REFERENCE_REPO_DIR, it only consults the setting in
- * its "scm" object (coming down from organization folder or other
- * pipeline checkout configuration advanced options). The same-named
- * environment variable is however defined in `git-refrepo-scripts`.
- * With this library class, the variable set at build agent level
- * can be honoured (along with DYNAMATRIX_UNSTASH_PREFERENCE="scm")
- * to use a refrepo defined (and somehow maintained) on that agent.
+ * TODO: the plugin itself does not define nor use the environment variable
+ *  {@code GIT_REFERENCE_REPO_DIR}, it only consults the setting in
+ *  its "scm" object (coming down from organization folder or other
+ *  pipeline checkout configuration advanced options). The same-named
+ *  environment variable is however defined in `git-refrepo-scripts`.
+ *  With this library class, the variable set at build agent level
+ *  can be honoured (along with {@code DYNAMATRIX_UNSTASH_PREFERENCE="scm"})
+ *  to use a refrepo defined (and somehow maintained) on that agent.
  */
 
 class DynamatrixStash {
-    // If closures were used to check out a stashName, track it here:
+    /** If closures were used to check out a stashName, track it here */
     private static def stashCode = [:]
 
-    // Track info about whatever we checked out with helpers here:
+    /** Track info about whatever we checked out with helpers here */
     private static def stashSCMVars = [:]
 
     static void deleteWS(def script) {
@@ -85,15 +96,17 @@ class DynamatrixStash {
 
     static String getGitRefrepoDirWSbase(def script) {
         // TODO: Find a way to know build agent workdir - that
-        // is what we want; "path relative to workspace" may lie
+        //  is what we want; "path relative to workspace" may lie
         if (!useGitRefrepoDirWS(script)) return null
         return "${script.env.WORKSPACE}/../.gitcache-dynamatrix"
     }
 
+    /**
+     * Returns the reference repository URL usable by git-client-plugin
+     * or null if none was found.
+     */
     static String getGitRefrepoDir(def script) {
         // NOTE: Have this logic defined and extensible in one place
-        // Returns the reference repository URL usable by git-client-plugin
-        // or null if none was found.
         String refrepo
 
         // Does the current build agent's set of envvars declare the path?
@@ -119,31 +132,33 @@ class DynamatrixStash {
         return null
     }
 
+    /**
+     * Helper to produce a git checkout with the parameter array
+     * similar to that of the standard checkout() step, which we
+     * can tune here. The optional "coRef" can specify the code
+     * revision to checkout, as branch name e.g. "master", or as
+     * the commit hash identifier, or a tag as "refs/tags/v1.2.3".<br/>
+     *
+     * This routine only intrudes in a few parts of the scmParams
+     * spec, if customized by run-time circumstances and not
+     * specified by caller: the $class, branches, and extensions
+     * for git reference repository.<br/>
+     *
+     * Example code that caller might directly specify:
+     * <pre>
+     *    checkout([$class: 'GitSCM', branches: [[name: "refs/tags/v2.7.4"]],
+     *        doGenerateSubmoduleConfigurations: false,
+     *        extensions: [
+     *            [$class: 'SubmoduleOption', disableSubmodules: false,
+     *             parentCredentials: false, recursiveSubmodules: false,
+     *             reference: '', trackingSubmodules: false]
+     *        ],
+     *        submoduleCfg: [],
+     *        userRemoteConfigs: [[url: "https://github.com/networkupstools/nut"]]
+     *    ])
+     * </pre>
+     */
     static def checkoutGit(def script, Map scmParams = [:], String coRef = null) {
-        // Helper to produce a git checkout with the parameter array
-        // similar to that of the standard checkout() step, which we
-        // can tune here. The optional "coRef" can specify the code
-        // revision to checkout, as branch name e.g. "master", or as
-        // the commit hash identifier, or a tag as "refs/tags/v1.2.3".
-
-        // This routine only intrudes in a few parts of the scmParams
-        // spec, if customized by run-time circumstances and not
-        // specified by caller: the $class, branches, and extensions
-        // for git reference repository.
-
-/* // Example code that caller might directly specify:
-    checkout([$class: 'GitSCM', branches: [[name: "refs/tags/v2.7.4"]],
-        doGenerateSubmoduleConfigurations: false,
-        extensions: [
-            [$class: 'SubmoduleOption', disableSubmodules: false,
-             parentCredentials: false, recursiveSubmodules: false,
-             reference: '', trackingSubmodules: false]
-        ],
-        submoduleCfg: [],
-        userRemoteConfigs: [[url: "https://github.com/networkupstools/nut"]]
-        ])
-*/
-
         if (!scmParams.containsKey('$class')) {
             script.echo "scmParams: inject class"
             scmParams << [$class: 'GitSCM']
@@ -203,9 +218,11 @@ class DynamatrixStash {
         return s
     }
 
+    /**
+     * Similar to {@link #checkoutGit}(), but for an SCM class; inspired by
+     * https://issues.jenkins.io/browse/JENKINS-43894?focusedCommentId=332158
+     */
     static def checkoutSCM(def script, def scmParams, String coRef = null) {
-        // Similar to checkoutGit() above, but for an SCM class; inspired by
-        // https://issues.jenkins.io/browse/JENKINS-43894?focusedCommentId=332158
         Field field = null
 
         if (scmParams instanceof hudson.plugins.git.GitSCM) {
@@ -300,12 +317,15 @@ class DynamatrixStash {
         return s
     }
 
+    /**
+     * Per https://plugins.jenkins.io/workflow-scm-step/ the common
+     * "scm" is a Map maintained by the pipeline, so we can tweak it
+     * Per other observations, it can be e.g. a GitSCM object instead.<br/>
+     *
+     * In any case, use a clone to avoid manipulating options of the
+     * original object (refrepo, etc.) when tuning individual builds.
+     */
     static def cloneSCM(def script, def scm = null) {
-        // Per https://plugins.jenkins.io/workflow-scm-step/ the common
-        // "scm" is a Map maintained by the pipeline, so we can tweak it
-        // Per other observations, it can be e.g. a GitSCM object instead.
-        // In any case, use a clone to avoid manipulating options of the
-        // original object (refrepo, etc.) when tuning individual builds.
         def clonedScm = null
         if (scm == null) scm = script.scm
 
@@ -341,8 +361,8 @@ class DynamatrixStash {
         return checkoutCleanSrc(script, stashName, true, scmbody)
     }
 
+    /** Optional closure can fully detail how the code is checked out */
     static def checkoutCleanSrc(def script, String stashName = null, Boolean untieRefrepoNow = true, Closure scmbody = null) {
-        // Optional closure can fully detail how the code is checked out
         deleteWS(script)
 
         def scm = cloneSCM(script)
@@ -383,9 +403,11 @@ class DynamatrixStash {
         return res
     } // checkoutCleanSrc()
 
+    /**
+     * If we made a git checkout with a refrepo, untie it before stashing
+     * https://stackoverflow.com/questions/2248228/how-to-detach-alternates-after-git-clone-reference
+     */
     static void untieRefrepo(def script) {
-        // If we made a git checkout with a refrepo, untie it before stashing
-        // https://stackoverflow.com/questions/2248228/how-to-detach-alternates-after-git-clone-reference
         // TODO: Would a `git gc` reduce footprint to stash?
         if (script.isUnix()) {
             script.sh label:"Untie the git checkout from reference repo (if any)", script:"""
@@ -411,21 +433,22 @@ echo "[DEBUG] Files in `pwd`: `find . -type f | wc -l` and all FS objects under:
         return checkoutCleanSrcNamed(script, stashName, true, scmbody)
     }
 
+    /**
+     * Optional closure can fully detail how the code is checked out.<br/>
+     * Remember last used method for this stashName,
+     * we may have to replay it on some workers
+     */
     static def checkoutCleanSrcNamed(def script, String stashName, Boolean untieRefrepoNow, Closure scmbody = null) {
         // Different name because groovy gets lost with parameter count
-        // when some can be defaulted
-
-        // Optional closure can fully detail how the code is checked out
-        // Remember last used method for this stashName,
-        // we may have to replay it on some workers
+        // when some can be defaulted.
         script.echo "Saving scmbody for ${stashName}: ${Utils.castString(scmbody)}"
         stashCode[stashName] = scmbody
         script.echo "Calling actual checkoutCleanSrc()"
         return checkoutCleanSrc(script, stashName, untieRefrepoNow, scmbody)
     } // checkoutCleanSrcNamed()
 
+    /** Optional closure can fully detail how the code is checked out */
     static def stashCleanSrc(def script, String stashName, Closure scmbody = null) {
-        // Optional closure can fully detail how the code is checked out
         def res = checkoutCleanSrcNamed(script, stashName, true, scmbody)
 
         // Be sure to get also "hidden" files like .* in Unix customs => .git*
@@ -452,9 +475,10 @@ git status || true
         return res
     } // stashCleanSrc()
 
+    /** only unstashes into current dir() from caller,
+     * no pre-cleanup done here (may be in caller)
+     */
     static def unstashScriptedSrc(def script, String stashName) {
-        // only unstashes into current dir() from caller,
-        // no pre-cleanup done here (may be in caller)
         def res = script.unstash (stashName)
         if (script.isUnix()) {
             // Try a workaround with `git init` per
@@ -473,16 +497,19 @@ echo "[DEBUG] Files in `pwd`: `find . -type f | wc -l` and all FS objects under:
         return res
     }
 
+    /**
+     * lock: rely on Lockable Resources plugin<br/>
+     *
+     * TODO: try/catch to do similar via filesystem, e.g. using some
+     *  file with the name of the build in that directory.<br/>
+     *
+     * NOTE: different build agents may be using the same filesystem
+     * with the git-cache (containers on same host, NFS share, etc.)
+     * so naming a lock by agent name alone may be folly.
+     * See also:
+     *   https://stackoverflow.com/questions/36581015/accessing-the-current-jenkins-build-in-groovy-script
+     */
     synchronized static def checkoutCleanSrcRefrepoWS(def script, String stashName) {
-        // lock: rely on Lockable Resources plugin
-        // TODO: try/catch to do similar via filesystem, e.g. using some
-        // file with the name of the build in that directory.
-        // NOTE: different build agents may be using the same filesystem
-        // with the git-cache (containers on same host, NFS share, etc.)
-        // so naming a lock by agent name alone may be folly.
-        // See also:
-        //   https://stackoverflow.com/questions/36581015/accessing-the-current-jenkins-build-in-groovy-script
-
         def scm = cloneSCM(script)
 
         if (!(Utils.isMap(scm)

--- a/src/org/nut/dynamatrix/NodeCaps.groovy
+++ b/src/org/nut/dynamatrix/NodeCaps.groovy
@@ -113,7 +113,7 @@ class NodeCaps implements Cloneable {
             //this.script.println "[DEBUG] raw nodeCaps: " + this
             this.script.println "[DEBUG] nodeCaps.labelExpr: " + this.labelExpr
             this.script.println "[DEBUG] nodeCaps.nodeData.size(): " + this.nodeData.size()
-            this.nodeData.keySet().each() {nodeName ->
+            this.nodeData.keySet().each() {String nodeName ->
                 if (nodeName == null) return // continue
                 this.script.println "[DEBUG] nodeCaps.nodeData[${nodeName}].labelMap.size()\t: " + this.nodeData[nodeName].labelMap.size()
                 this.nodeData[nodeName].labelMap.keySet().each() {String label ->
@@ -177,7 +177,7 @@ class NodeCaps implements Cloneable {
                 // of the variable axis itself (like fixed 'COMPILER'
                 // string for variable part '${COMPILER}' in originally
                 // requested axis name '${COMPILER}VAR').
-                this.resolveAxisName(varAxis).each() {expandedAxisName ->
+                this.resolveAxisName(varAxis).each() {def expandedAxisName ->
                     if (!Utils.isStringNotEmpty(expandedAxisName)) return; // continue
 
                     // This layer of recursion gets us fixed-string name
@@ -185,7 +185,7 @@ class NodeCaps implements Cloneable {
                     // 'CLANG' for variable '${COMPILER}' in originally
                     // requested axis name '${COMPILER}VAR').
                     // Pattern looks into nodeCaps.
-                    this.resolveAxisValues(expandedAxisName).each() {expandedAxisValue ->
+                    this.resolveAxisValues(expandedAxisName).each() {def expandedAxisValue ->
                         if (!Utils.isStringNotEmpty(expandedAxisValue)) return; // continue
 
                         // In the original axis like '${COMPILER}VER' apply current item
@@ -221,7 +221,7 @@ class NodeCaps implements Cloneable {
 
         if (Utils.isRegex(axis)) {
             // Return label keys which match the expression
-            this.nodeData.keySet().each() {nodeName ->
+            this.nodeData.keySet().each() {String nodeName ->
                 if (nodeName == null) return // continue
 
                 this.nodeData[nodeName].labelMap.keySet().each() {String label ->
@@ -263,7 +263,7 @@ class NodeCaps implements Cloneable {
      *
      * @see #resolveAxisValues(Object, boolean)
      */
-    def resolveAxisValues(Object axis, node, boolean returnAssignments = false) {
+    def resolveAxisValues(Object axis,  String node, boolean returnAssignments = false) {
         /* Look into a single node */
         Set res = []
         def debugErrors = this.shouldDebugErrors()
@@ -383,7 +383,7 @@ class NodeCaps implements Cloneable {
      * See comments in the per-node variant - this method calls it
      * for all selected and cached nodes, and aggregates the results.
      *
-     * @see #resolveAxisValues(Object, Object, boolean)
+     * @see #resolveAxisValues(Object, String, boolean)
      */
     def resolveAxisValues(Object axis, boolean returnAssignments = false) {
         Set res = []
@@ -406,7 +406,7 @@ class NodeCaps implements Cloneable {
 
         if (debugTrace) this.script.println "[DEBUG] resolveAxisValues(${returnAssignments}): looking for: ${Utils.castString(axis)}"
 
-        this.nodeData.keySet().each() {nodeName ->
+        this.nodeData.keySet().each() {String nodeName ->
             if (nodeName == null) return // continue
             def nres = resolveAxisValues(axis, nodeName, returnAssignments)
             if (nres != null && nres.size() > 0)

--- a/src/org/nut/dynamatrix/NodeData.groovy
+++ b/src/org/nut/dynamatrix/NodeData.groovy
@@ -8,24 +8,28 @@ import hudson.model.Node;
 
 import org.nut.dynamatrix.Utils;
 
+/**
+ * This class encapsulates interesting data about a single Jenkins {@link Node}.
+ * A lot of these data points are stored in a {@link NodeCaps} object below.
+ */
 class NodeData {
-    /* This class encapsulates interesting data about a single Jenkins Node.
-     * A lot of these data points are stored in a NodeCaps object below.
-     */
-
     // Info about the build agent (node) detailed here.
     //NotSerializable//public final hudson.model.Node node
     public final String name
 
-    // Original full-string set of labels received from Jenkins Node:
+    /** Original full-string set of labels received from Jenkins Node */
     public final String labelString
-    // Labels split into an array (or rather sorted set) by whitespaces:
+
+    /** Labels split into an array (or rather sorted set) by whitespaces */
     public final TreeSet<String> labelSet
-    // The array of labels split further into a Map: those with an equality
-    // sign are converted into key=[valueSet] (since our use-case can have
-    // many values with same key, like compiler versions); those without
-    // the sign become key=null; also the original unique key=value strings
-    // are saved as keys similarly mapped to null:
+
+    /**
+     * The array of labels split further into a Map: those with an equality
+     * sign are converted into key=[valueSet] (since our use-case can have
+     * many values with same key, like compiler versions); those without
+     * the sign become key=null; also the original unique key=value strings
+     * are saved as keys similarly mapped to null:
+     */
     public final Map<String, Object> labelMap
 
     public NodeData(Object nodeOrig) throws Exception {

--- a/src/org/nut/dynamatrix/Utils.groovy
+++ b/src/org/nut/dynamatrix/Utils.groovy
@@ -12,7 +12,7 @@ class Utils {
     public static final def classesClosures = [org.jenkinsci.plugins.workflow.cps.CpsClosure2, groovy.lang.Closure, Closure]
 
     @NonCPS
-    public static boolean isString(obj) {
+    public static boolean isString(def obj) {
         if (obj == null) return false;
         if (obj.getClass() in classesStrings) return true;
         if (obj instanceof String) return true;
@@ -22,7 +22,7 @@ class Utils {
     }
 
     @NonCPS
-    public static boolean isRegex(obj) {
+    public static boolean isRegex(def obj) {
         if (obj == null) return false;
         if (obj.getClass() in classesRegex) return true;
         if (obj instanceof java.util.regex.Pattern) return true;
@@ -30,21 +30,21 @@ class Utils {
     }
 
     @NonCPS
-    public static boolean isStringOrRegex(obj) {
+    public static boolean isStringOrRegex(def obj) {
         if (obj == null) return false;
         if (isString(obj) || isRegex(obj)) return true;
         return false;
     }
 
     @NonCPS
-    public static boolean isStringNotEmpty(obj) {
+    public static boolean isStringNotEmpty(def obj) {
         if (!isString(obj)) return false;
         if ("".equals(obj)) return false;
         return true;
     }
 
     @NonCPS
-    public static boolean isStringOrRegexNotEmpty(obj) {
+    public static boolean isStringOrRegexNotEmpty(def obj) {
         if (isString(obj)) {
             if ("".equals(obj)) return false;
             return true;
@@ -55,7 +55,7 @@ class Utils {
     }
 
     @NonCPS
-    public static boolean isMap(obj) {
+    public static boolean isMap(def obj) {
         if (obj == null) return false;
         if (obj.getClass() in classesMaps) return true;
         if (obj instanceof Map) return true;
@@ -63,13 +63,13 @@ class Utils {
     }
 
     @NonCPS
-    public static boolean isMapNotEmpty(obj) {
+    public static boolean isMapNotEmpty(def obj) {
         if (!isMap(obj)) return false;
         return (obj.size() > 0)
     }
 
     @NonCPS
-    public static boolean isList(obj) {
+    public static boolean isList(def obj) {
         if (obj == null) return false;
         if (obj.getClass() in classesLists) return true;
         if (obj instanceof Set) return true;
@@ -80,13 +80,13 @@ class Utils {
     }
 
     @NonCPS
-    public static boolean isListNotEmpty(obj) {
+    public static boolean isListNotEmpty(def obj) {
         if (!isList(obj)) return false;
         return (obj.size() > 0)
     }
 
     @NonCPS
-    public static boolean isNode(obj) {
+    public static boolean isNode(def obj) {
         if (obj == null) return false;
         if (obj.getClass() in [hudson.model.Node] || obj in hudson.model.Node) return true;
         if (obj instanceof hudson.model.Node) return true;
@@ -94,7 +94,7 @@ class Utils {
     }
 
     @NonCPS
-    public static boolean isClosure(obj) {
+    public static boolean isClosure(def obj) {
         if (obj == null) return false;
         if (obj.getClass() in classesClosures) return true;
         if (obj in org.jenkinsci.plugins.workflow.cps.CpsClosure2) return true;
@@ -105,13 +105,13 @@ class Utils {
     }
 
     @NonCPS
-    public static boolean isClosureNotEmpty(obj) {
+    public static boolean isClosureNotEmpty(def obj) {
         if (!isClosure(obj)) return false;
         return ( obj != {} )
     }
 
     @NonCPS
-    public static String castString(obj) {
+    public static String castString(def obj) {
         return "<${obj?.getClass()}>(${obj?.toString()})"
     }
 
@@ -182,7 +182,7 @@ class Utils {
      *
      * Returns the result of merge (or whatever did happen there).
      */
-    static def mergeMapSet(orig, addon, boolean debug = false) {
+    static def mergeMapSet(def orig, def addon, boolean debug = false) {
         // Note: debug println() below might not go anywhere
         if (isList(orig)) {
             if (isList(addon)) {

--- a/src/org/nut/dynamatrix/dynamatrixGlobalState.groovy
+++ b/src/org/nut/dynamatrix/dynamatrixGlobalState.groovy
@@ -1,47 +1,69 @@
 package org.nut.dynamatrix;
 
 class dynamatrixGlobalState {
-    // buildMatrixCell* steps populate this with their build analysis results
+    /** buildMatrixCell* steps populate this with their build analysis results */
     static ArrayList<Object> issueAnalysis = []
+    /** buildMatrixCell* steps populate this with their build analysis results */
     static ArrayList<Object> issueAnalysisCppcheck = []
-    // same, but try to deduplicate same results recevied by different tools
+
+    /**
+     * Same as {@link #issueAnalysis}, but try to deduplicate equivalent
+     * results received by different tools or in different scenarios.
+     */
     static ArrayList<Object> issueAnalysisAggregated = []
+
+    /**
+     * Same as {@link #issueAnalysisCppcheck}, but try to deduplicate equivalent
+     * results received by different tools or in different scenarios.
+     */
     static ArrayList<Object> issueAnalysisAggregatedCppcheck = []
 
-    // Some steps in a pipeline, such as git checkouts sped up by a local
-    // reference repository, should use a worker (or even a definitive one).
-    // Due to Pipeline DSL constraints, if we use labels we must use them
-    // everywhere and can not juggle if-then to specify "agent any" or some
-    // other option instead... only a string for the label expression.
+    /**
+     * Some steps in a pipeline, such as git checkouts sped up by a local
+     * reference repository, should use a worker (or even a definitive one).
+     * Due to Pipeline DSL constraints, if we use labels we must use them
+     * everywhere and can not juggle if-then to specify "agent any" or some
+     * other option instead... only a string for the label expression.
+     */
     static String labelDefaultWorker = null
-    // Something preferably with cached sources nearby:
+    /** Something preferably with cached sources nearby */
     static String labelCheckoutWorker = null
-    // Something with tools to generate MAN, PDF, HTML... and to spell-check:
+    /** Something with tools to generate MAN, PDF, HTML... and to spell-check */
     static String labelDocumentationWorker = null
 
     static Boolean useGitRefrepoDirWS = false
 
-    // For build quality evolution analysis, which branch is the reference?
+    /** For build quality evolution analysis, which branch is the reference? */
     static String branchDefaultStable = null
 
-    // These settings can make constructors of NodeCaps and NodeData more
-    // verbose (when called from wrapping code that passes these args)
+    /**
+     * These settings can make constructors of {@link NodeCaps} and
+     * {@link NodeData} more verbose (when called from wrapping code
+     * that passes these args)
+     */
     static Boolean enableDebugTrace = false
+    /** @see #enableDebugTrace */
     static Boolean enableDebugTraceFailures = true
+    /** @see #enableDebugTrace */
     static Boolean enableDebugErrors = true
+    /** @see #enableDebugTrace */
     static Boolean enableDebugMilestones = true
+    /** @see #enableDebugTrace */
     static Boolean enableDebugMilestonesDetails = false
 
-    // (Duplicate) Debug of some key troubleshooting
-    // points to System.(out|err).println?
+    /** (Duplicate) Debug of some key troubleshooting
+     * points to System.(out|err).println? */
     static Boolean enableDebugSysprint = true
 
-    // Takes a (DynamatrixSingleBuildConfig) object as argument and returns
-    // a string. Can be used for definition of "meaningful" short tags by a
-    // project, like "gnu99-gcc-freebsd-nowarn" or "c17-clang-xcode10.2-warn"
-    // instead of a default long list of variables that impact the uniqueness
-    // of a build setup. For one reference implementation, see
-    //    dynamatrixGlobalState.stageNameFunc = DynamatrixSingleBuildConfig.&C_StageNameTagFunc
+    /**
+     * Takes a {@link DynamatrixSingleBuildConfig} object as argument and
+     * returns a string. Can be used for definition of "meaningful" short
+     * tags by a project, like {@code "gnu99-gcc-freebsd-nowarn"} or
+     * {@code "c17-clang-xcode10.2-warn"} instead of a default long list
+     * of variables that impact the uniqueness of a build setup. For one
+     * reference implementation, see
+     *    <pre>dynamatrixGlobalState.stageNameFunc = DynamatrixSingleBuildConfig.&C_StageNameTagFunc</pre>
+     */
     static def stageNameFunc = null
 }
 

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -1,7 +1,7 @@
 import org.nut.dynamatrix.dynamatrixGlobalState;
 import org.nut.dynamatrix.Utils;
 
-/*
+/**
  * Return the label (expression) string for a worker that handles
  * git checkouts and stashing of the source for other build agents.
  * Unlike the other agents, this worker should have appropriate
@@ -15,6 +15,12 @@ def labelDefaultWorker() {
     return 'master-worker'
 }
 
+/**
+ * Returns the Jenkins agent label (expression) for a worker that
+ * can be used for SCM checkouts.
+ * @see infra#labelDefaultWorker
+ * @see dynamatrixGlobalState#labelCheckoutWorker
+ */
 def labelCheckoutWorker() {
     // Global/modifiable config point:
     if (Utils.isStringNotEmpty(dynamatrixGlobalState.labelCheckoutWorker)) {
@@ -23,6 +29,18 @@ def labelCheckoutWorker() {
     return labelDefaultWorker()
 }
 
+/**
+ * Returns the Jenkins agent label (expression) for a worker that
+ * can be used for documentation processing (spell check, HTML/PDF
+ * rendering, etc.)<br/>
+ *
+ * As a fallback (if not specified in the
+ * {@link dynamatrixGlobalState#labelDocumentationWorker} setting,
+ * looks for {@code 'doc-builder'} in currently defined build agents.
+ *
+ * @see infra#labelDefaultWorker
+ * @see dynamatrixGlobalState#labelDocumentationWorker
+ */
 def labelDocumentationWorker() {
     // Global/modifiable config point:
     if (Utils.isStringNotEmpty(dynamatrixGlobalState.labelDocumentationWorker)) {
@@ -38,6 +56,11 @@ def labelDocumentationWorker() {
     return labelDefaultWorker()
 }
 
+/**
+ * Returns the default "stable branch" name for SCM operations, from
+ * settings or a hard-coded default.
+ * @see dynamatrixGlobalState#branchDefaultStable
+ */
 def branchDefaultStable() {
     if (Utils.isStringNotEmpty(dynamatrixGlobalState.branchDefaultStable)) {
         return dynamatrixGlobalState.branchDefaultStable
@@ -52,6 +75,8 @@ def branchDefaultStable() {
  * Compares the current branch and target branch and list the changed files.
  *
  * @return the PR or directly branch changed files.
+ *
+ * @see #listChangedFilesJenkinsData
  */
 Set listChangedFilesGitWorkspace() {
     Set changedFiles = []
@@ -90,6 +115,12 @@ Set listChangedFilesGitWorkspace() {
     return changedFiles
 }
 
+/**
+ * Returns the source code path names impacted by the current build
+ * as compared to an earlier one, according to Jenkins' own logic.
+ *
+ * @see #listChangedFilesGitWorkspace
+ */
 Set listChangedFilesJenkinsData() {
     // https://stackoverflow.com/a/59462020/4715872
     Set changedFiles = []
@@ -108,6 +139,14 @@ Set listChangedFilesJenkinsData() {
     return changedFiles
 }
 
+/**
+ * Compares different clues to list the changed files.
+ *
+ * @return the PR or directly branch changed files.
+ *
+ * @see #listChangedFilesJenkinsData
+ * @see #listChangedFilesGitWorkspace
+ */
 Set listChangedFiles() {
     Set changedFiles = listChangedFilesGitWorkspace()
     changedFiles += listChangedFilesJenkinsData()


### PR DESCRIPTION
Improve maintainability, hopefully declaring the types would help avoid glitches like
````
Building with GCC-9 STD=gnu99 STD=gnu++98 on amd64 64-bit illumos-omnios platform for
  (ARCH_BITS=32&&ARCH32=i686-w64-mingw32&&COMPILER=GCC&&OS_DISTRO=ubuntu-impish&&OS_FAMILY=mingw)  ...
````
("omnios" is not "ubuntu")!