### PR TITLE
Fix build-info page icons

### DIFF
--- a/src/org/nut/dynamatrix/Dynamatrix.groovy
+++ b/src/org/nut/dynamatrix/Dynamatrix.groovy
@@ -1845,7 +1845,7 @@ def parallelStages = prepareDynamatrix(
 
             // Used to be '/images/48x48/warning.png', an arg for createSummary()
             // Maybe sourced from https://github.com/jenkinsci/jenkins/blob/master/war/src/main/webapp/images/48x48 :
-            def badgeImageDSBCcaughtException = '/images/48x48/aborted.png'
+            def badgeImageDSBCcaughtException = '/images/48x48/aborted.png'	// '/images/svgs/warning.svg'
 
             // Support optional "failFastSafe" mechanism to raise the "mustAbort" flag
             if (true) { // scoping

--- a/src/org/nut/dynamatrix/Dynamatrix.groovy
+++ b/src/org/nut/dynamatrix/Dynamatrix.groovy
@@ -1843,6 +1843,10 @@ def parallelStages = prepareDynamatrix(
                 sbName = " :: as part of slowBuild filter: ${script.env.CI_SLOW_BUILD_FILTERNAME}"
             }
 
+            // Used to be '/images/48x48/warning.png', an arg for createSummary()
+            // Maybe sourced from https://github.com/jenkinsci/jenkins/blob/master/war/src/main/webapp/images/48x48 :
+            def badgeImageDSBCcaughtException = '/images/48x48/aborted.png'
+
             // Support optional "failFastSafe" mechanism to raise the "mustAbort" flag
             if (true) { // scoping
                 // Note: such implementation effectively relies on the node{}
@@ -2055,7 +2059,7 @@ def parallelStages = prepareDynamatrix(
                                             script.echo "[ERROR] " + msgEx
                                         }
 
-                                        createSummary(msgEx, 'warning.gif', "${dsbc.objectID}-exception-${dsbc.startCount}")
+                                        createSummary(msgEx, badgeImageDSBCcaughtException, "${dsbc.objectID}-exception-${dsbc.startCount}")
                                         break
                                 }
                             }
@@ -2104,7 +2108,7 @@ def parallelStages = prepareDynamatrix(
                                     script.echo "[ERROR] " + msgEx
                                 }
 
-                                createSummary(msgEx, 'warning.gif', "${dsbc.objectID}-exception-${dsbc.startCount}")
+                                createSummary(msgEx, badgeImageDSBCcaughtException, "${dsbc.objectID}-exception-${dsbc.startCount}")
                             }
                         }
                         dsbc.thisDynamatrix?.updateProgressBadge()
@@ -2149,7 +2153,7 @@ def parallelStages = prepareDynamatrix(
                                     script.echo "[ERROR] " + msgEx
                                 }
 
-                                createSummary(msgEx, 'warning.gif', "${dsbc.objectID}-exception-${dsbc.startCount}")
+                                createSummary(msgEx, badgeImageDSBCcaughtException, "${dsbc.objectID}-exception-${dsbc.startCount}")
                             }
                         }
                         dsbc.thisDynamatrix?.updateProgressBadge()
@@ -2199,7 +2203,7 @@ def parallelStages = prepareDynamatrix(
                                     script.echo "[ERROR] " + msgEx
                                 }
 
-                                createSummary(msgEx, 'warning.gif', "${dsbc.objectID}-exception-${dsbc.startCount}")
+                                createSummary(msgEx, badgeImageDSBCcaughtException, "${dsbc.objectID}-exception-${dsbc.startCount}")
                             }
                         }
                         dsbc.thisDynamatrix?.updateProgressBadge()
@@ -2242,7 +2246,7 @@ def parallelStages = prepareDynamatrix(
                                     script.echo "[ERROR] " + msgEx
                                 }
 
-                                createSummary(msgEx, 'warning.gif', "${dsbc.objectID}-exception-${dsbc.startCount}")
+                                createSummary(msgEx, badgeImageDSBCcaughtException, "${dsbc.objectID}-exception-${dsbc.startCount}")
                             }
                         }
                         dsbc.thisDynamatrix?.updateProgressBadge()
@@ -2274,7 +2278,7 @@ def parallelStages = prepareDynamatrix(
                             script.echo "[ERROR] " + msgEx
                         }
 
-                        createSummary(msgEx, 'warning.gif', "${dsbc.objectID}-exception-${dsbc.startCount}")
+                        createSummary(msgEx, badgeImageDSBCcaughtException, "${dsbc.objectID}-exception-${dsbc.startCount}")
 
                         printStackTraceStderrOptional(t)
                         throw t

--- a/src/org/nut/dynamatrix/Dynamatrix.groovy
+++ b/src/org/nut/dynamatrix/Dynamatrix.groovy
@@ -2055,7 +2055,7 @@ def parallelStages = prepareDynamatrix(
                                             script.echo "[ERROR] " + msgEx
                                         }
 
-                                        createSummary(msgEx, '/images/48x48/warning.png', "${dsbc.objectID}-exception-${dsbc.startCount}")
+                                        createSummary(msgEx, 'warning.gif', "${dsbc.objectID}-exception-${dsbc.startCount}")
                                         break
                                 }
                             }
@@ -2104,7 +2104,7 @@ def parallelStages = prepareDynamatrix(
                                     script.echo "[ERROR] " + msgEx
                                 }
 
-                                createSummary(msgEx, '/images/48x48/warning.png', "${dsbc.objectID}-exception-${dsbc.startCount}")
+                                createSummary(msgEx, 'warning.gif', "${dsbc.objectID}-exception-${dsbc.startCount}")
                             }
                         }
                         dsbc.thisDynamatrix?.updateProgressBadge()
@@ -2149,7 +2149,7 @@ def parallelStages = prepareDynamatrix(
                                     script.echo "[ERROR] " + msgEx
                                 }
 
-                                createSummary(msgEx, '/images/48x48/warning.png', "${dsbc.objectID}-exception-${dsbc.startCount}")
+                                createSummary(msgEx, 'warning.gif', "${dsbc.objectID}-exception-${dsbc.startCount}")
                             }
                         }
                         dsbc.thisDynamatrix?.updateProgressBadge()
@@ -2199,7 +2199,7 @@ def parallelStages = prepareDynamatrix(
                                     script.echo "[ERROR] " + msgEx
                                 }
 
-                                createSummary(msgEx, '/images/48x48/warning.png', "${dsbc.objectID}-exception-${dsbc.startCount}")
+                                createSummary(msgEx, 'warning.gif', "${dsbc.objectID}-exception-${dsbc.startCount}")
                             }
                         }
                         dsbc.thisDynamatrix?.updateProgressBadge()
@@ -2242,7 +2242,7 @@ def parallelStages = prepareDynamatrix(
                                     script.echo "[ERROR] " + msgEx
                                 }
 
-                                createSummary(msgEx, '/images/48x48/warning.png', "${dsbc.objectID}-exception-${dsbc.startCount}")
+                                createSummary(msgEx, 'warning.gif', "${dsbc.objectID}-exception-${dsbc.startCount}")
                             }
                         }
                         dsbc.thisDynamatrix?.updateProgressBadge()
@@ -2274,7 +2274,7 @@ def parallelStages = prepareDynamatrix(
                             script.echo "[ERROR] " + msgEx
                         }
 
-                        createSummary(msgEx, '/images/48x48/warning.png', "${dsbc.objectID}-exception-${dsbc.startCount}")
+                        createSummary(msgEx, 'warning.gif', "${dsbc.objectID}-exception-${dsbc.startCount}")
 
                         printStackTraceStderrOptional(t)
                         throw t

--- a/vars/buildMatrixCellCI.groovy
+++ b/vars/buildMatrixCellCI.groovy
@@ -516,14 +516,14 @@ done
                 // after the logic below, an arg for createSummary()
                 // Maybe sourced from https://github.com/jenkinsci/jenkins/blob/master/war/src/main/webapp/images/48x48 :
                 def sumimg = null
-                def suming_prefix = '/images/48x48/'
-                def suming_suffix = '.png'
+                def suming_prefix = '/images/svgs/'
+                def suming_suffix = '.svg'
                 if (dsbc?.isAllowedFailure) {
                     sumtxt = "[UNSTABLE (non-success is expected)] "
-                    sumimg = 'yellow'	// 'warning'
+                    sumimg = 'warning'
                 } else {
                     sumtxt = "[FAILURE (not anticipated)] "
-                    sumimg = 'red'		// 'error'
+                    sumimg = 'error'
                 }
 
                 if (Utils.isStringNotEmpty(msg))

--- a/vars/buildMatrixCellCI.groovy
+++ b/vars/buildMatrixCellCI.groovy
@@ -539,7 +539,7 @@ done
                 } catch (Throwable tF) {} // no-op, possibly some iteration/fileExists problem
                 sumtxt += "<li><a href='${env.BUILD_URL}/artifact/${lastLog}.gz'>${lastLog}.gz</a></li></ul>"
 
-                createSummary(text: sumtxt, icon: '/images/48x48/' + sumimg + '.png')
+                createSummary(text: sumtxt, icon: sumimg + '.gif')
             } catch (Throwable t) {} // no-op, possibly missing badge plugin
         }
 

--- a/vars/buildMatrixCellCI.groovy
+++ b/vars/buildMatrixCellCI.groovy
@@ -511,13 +511,19 @@ done
             // so developers can quickly find the faults
             try {
                 def sumtxt = null
+
+                // Used to be '/images/48x48/(error|warning).png'
+                // after the logic below, an arg for createSummary()
+                // Maybe sourced from https://github.com/jenkinsci/jenkins/blob/master/war/src/main/webapp/images/48x48 :
                 def sumimg = null
+                def suming_prefix = '/images/48x48/'
+                def suming_suffix = '.png'
                 if (dsbc?.isAllowedFailure) {
                     sumtxt = "[UNSTABLE (non-success is expected)] "
-                    sumimg = 'warning'
+                    sumimg = 'yellow'	// 'warning'
                 } else {
                     sumtxt = "[FAILURE (not anticipated)] "
-                    sumimg = 'error'
+                    sumimg = 'red'		// 'error'
                 }
 
                 if (Utils.isStringNotEmpty(msg))
@@ -539,7 +545,7 @@ done
                 } catch (Throwable tF) {} // no-op, possibly some iteration/fileExists problem
                 sumtxt += "<li><a href='${env.BUILD_URL}/artifact/${lastLog}.gz'>${lastLog}.gz</a></li></ul>"
 
-                createSummary(text: sumtxt, icon: sumimg + '.gif')
+                createSummary(text: sumtxt, icon: suming_prefix + sumimg + suming_suffix)
             } catch (Throwable t) {} // no-op, possibly missing badge plugin
         }
 

--- a/vars/dynamatrixPipeline.groovy
+++ b/vars/dynamatrixPipeline.groovy
@@ -559,7 +559,7 @@ def call(dynacfgBase = [:], dynacfgPipeline = [:]) {
                                         try {
                                             createSummary(text: "Saved the list of slowBuild stages into a text artifact " +
                                                 "<a href='${env.BUILD_URL}/artifact/.ci.slowBuildStages-list.txt'>.ci.slowBuildStages-list.txt</a>",
-                                                icon: '/images/48x48/notepad.png')
+                                                icon: 'text.gif')
                                         } catch (Throwable ts) {
                                             echo "WARNING: Tried to createSummary(), but failed to; is the jenkins-badge-plugin installed?"
                                             if (dynamatrixGlobalState.enableDebugTrace) echo t.toString()
@@ -599,7 +599,7 @@ def call(dynacfgBase = [:], dynacfgPipeline = [:]) {
                                         // Note: replace goes by regex so '\*'
                                         sbSummaryCount = sbSummaryCount.replaceAll('\n\t\\* ', '</li><li>').replaceFirst('</li>', '<p>Detailed hit counts:<ul>') + '</li></ul></p>'
                                     }
-                                    createSummary(text: sbSummary + sbSummaryCount, icon: '/images/48x48/notepad.png')
+                                    createSummary(text: sbSummary + sbSummaryCount, icon: 'text.gif')
                                 } catch (Throwable t) {
                                     echo "WARNING: Tried to addInfoBadge() and createSummary(), but failed to; is the jenkins-badge-plugin installed?"
                                     if (dynamatrixGlobalState.enableDebugTrace) echo t.toString()
@@ -771,7 +771,7 @@ def call(dynacfgBase = [:], dynacfgPipeline = [:]) {
                                 currentBuild.result = 'ABORTED'
                                 def txt = "Only started ${mapCountStages.STARTED} (restarted ${mapCountStages.RESTARTED}) and completed ${mapCountStages.COMPLETED} dynamatrix 'slowBuild' stages, while we should have had ${stagesBinBuild.size() - 1} builds"
                                 try {
-                                    createSummary(text: "Build seems not finished: " + txt, icon: '/images/48x48/error.png')
+                                    createSummary(text: "Build seems not finished: " + txt, icon: 'error.gif')
                                 } catch (Throwable t) {} // no-op
                                 error txt
                             }
@@ -925,7 +925,7 @@ def call(dynacfgBase = [:], dynacfgPipeline = [:]) {
 
                         def txtOK = "Build completed successfully"
                         manager.addShortText(txtOK)
-                        createSummary(text: txtOK + ": " + txt, icon: '/images/48x48/notepad.png')
+                        createSummary(text: txtOK + ": " + txt, icon: 'text.gif')
                     } catch (Throwable t) {
                         echo "WARNING: Tried to addShortText() and createSummary(), but failed to; are the Groovy Postbuild plugin and jenkins-badge-plugin installed?"
                         if (dynamatrixGlobalState.enableDebugTrace) echo t.toString()
@@ -944,7 +944,7 @@ def call(dynacfgBase = [:], dynacfgPipeline = [:]) {
                         }
                         txt = "Not all went well: " + txt
                         manager.addShortText(txt)
-                        createSummary(text: txt, icon: '/images/48x48/warning.png')
+                        createSummary(text: txt, icon: 'warning.gif')
 
                         // returns Map<Result, Set<String>>
                         def mapres = dynamatrix.reportStageResults()
@@ -973,7 +973,7 @@ def call(dynacfgBase = [:], dynacfgPipeline = [:]) {
                                     txt += "</li>\n"
                                 }
                                 txt += "</nl>\n"
-                                createSummary(text: txt, icon: '/images/48x48/warning.png')
+                                createSummary(text: txt, icon: 'warning.gif')
                             }
                         }
                     } catch (Throwable t) {

--- a/vars/dynamatrixPipeline.groovy
+++ b/vars/dynamatrixPipeline.groovy
@@ -559,7 +559,8 @@ def call(dynacfgBase = [:], dynacfgPipeline = [:]) {
                                         try {
                                             createSummary(text: "Saved the list of slowBuild stages into a text artifact " +
                                                 "<a href='${env.BUILD_URL}/artifact/.ci.slowBuildStages-list.txt'>.ci.slowBuildStages-list.txt</a>",
-                                                icon: 'text.gif')
+                                                icon: '/images/svgs/document.svg'	// '/images/48x48/notepad.png'
+                                                )
                                         } catch (Throwable ts) {
                                             echo "WARNING: Tried to createSummary(), but failed to; is the jenkins-badge-plugin installed?"
                                             if (dynamatrixGlobalState.enableDebugTrace) echo t.toString()
@@ -599,7 +600,10 @@ def call(dynacfgBase = [:], dynacfgPipeline = [:]) {
                                         // Note: replace goes by regex so '\*'
                                         sbSummaryCount = sbSummaryCount.replaceAll('\n\t\\* ', '</li><li>').replaceFirst('</li>', '<p>Detailed hit counts:<ul>') + '</li></ul></p>'
                                     }
-                                    createSummary(text: sbSummary + sbSummaryCount, icon: 'text.gif')
+                                    createSummary(
+                                        text: sbSummary + sbSummaryCount,
+                                        icon: '/images/svgs/document.svg'	// '/images/48x48/notepad.png'
+                                        )
                                 } catch (Throwable t) {
                                     echo "WARNING: Tried to addInfoBadge() and createSummary(), but failed to; is the jenkins-badge-plugin installed?"
                                     if (dynamatrixGlobalState.enableDebugTrace) echo t.toString()
@@ -771,7 +775,10 @@ def call(dynacfgBase = [:], dynacfgPipeline = [:]) {
                                 currentBuild.result = 'ABORTED'
                                 def txt = "Only started ${mapCountStages.STARTED} (restarted ${mapCountStages.RESTARTED}) and completed ${mapCountStages.COMPLETED} dynamatrix 'slowBuild' stages, while we should have had ${stagesBinBuild.size() - 1} builds"
                                 try {
-                                    createSummary(text: "Build seems not finished: " + txt, icon: 'error.gif')
+                                    createSummary(
+                                        text: "Build seems not finished: " + txt,
+                                        icon: '/images/svgs/error.svg'	// '/images/48x48/error.png'
+                                        )
                                 } catch (Throwable t) {} // no-op
                                 error txt
                             }
@@ -925,7 +932,10 @@ def call(dynacfgBase = [:], dynacfgPipeline = [:]) {
 
                         def txtOK = "Build completed successfully"
                         manager.addShortText(txtOK)
-                        createSummary(text: txtOK + ": " + txt, icon: 'text.gif')
+                        createSummary(
+                            text: txtOK + ": " + txt,
+                            icon: '/images/svgs/document.svg'	// '/images/48x48/notepad.png'
+                            )
                     } catch (Throwable t) {
                         echo "WARNING: Tried to addShortText() and createSummary(), but failed to; are the Groovy Postbuild plugin and jenkins-badge-plugin installed?"
                         if (dynamatrixGlobalState.enableDebugTrace) echo t.toString()
@@ -944,7 +954,10 @@ def call(dynacfgBase = [:], dynacfgPipeline = [:]) {
                         }
                         txt = "Not all went well: " + txt
                         manager.addShortText(txt)
-                        createSummary(text: txt, icon: 'warning.gif')
+                        createSummary(
+                            text: txt,
+                            icon: '/images/svgs/warning.svg'	// '/images/48x48/warning.png'
+                        )
 
                         // returns Map<Result, Set<String>>
                         def mapres = dynamatrix.reportStageResults()
@@ -973,7 +986,10 @@ def call(dynacfgBase = [:], dynacfgPipeline = [:]) {
                                     txt += "</li>\n"
                                 }
                                 txt += "</nl>\n"
-                                createSummary(text: txt, icon: 'warning.gif')
+                                createSummary(
+                                    text: txt,
+                                    icon: '/images/svgs/warning.svg'	// '/images/48x48/warning.png'
+                                )
                             }
                         }
                     } catch (Throwable t) {

--- a/vars/dynamatrixPipeline.groovy
+++ b/vars/dynamatrixPipeline.groovy
@@ -559,7 +559,7 @@ def call(dynacfgBase = [:], dynacfgPipeline = [:]) {
                                         try {
                                             createSummary(text: "Saved the list of slowBuild stages into a text artifact " +
                                                 "<a href='${env.BUILD_URL}/artifact/.ci.slowBuildStages-list.txt'>.ci.slowBuildStages-list.txt</a>",
-                                                icon: '/images/svgs/document.svg'	// '/images/48x48/notepad.png'
+                                                icon: '/images/svgs/notepad.svg'	// '/images/48x48/notepad.png'
                                                 )
                                         } catch (Throwable ts) {
                                             echo "WARNING: Tried to createSummary(), but failed to; is the jenkins-badge-plugin installed?"
@@ -602,7 +602,7 @@ def call(dynacfgBase = [:], dynacfgPipeline = [:]) {
                                     }
                                     createSummary(
                                         text: sbSummary + sbSummaryCount,
-                                        icon: '/images/svgs/document.svg'	// '/images/48x48/notepad.png'
+                                        icon: '/images/svgs/notepad.svg'	// '/images/48x48/notepad.png'
                                         )
                                 } catch (Throwable t) {
                                     echo "WARNING: Tried to addInfoBadge() and createSummary(), but failed to; is the jenkins-badge-plugin installed?"
@@ -934,7 +934,7 @@ def call(dynacfgBase = [:], dynacfgPipeline = [:]) {
                         manager.addShortText(txtOK)
                         createSummary(
                             text: txtOK + ": " + txt,
-                            icon: '/images/svgs/document.svg'	// '/images/48x48/notepad.png'
+                            icon: '/images/svgs/notepad.svg'	// '/images/48x48/notepad.png'
                             )
                     } catch (Throwable t) {
                         echo "WARNING: Tried to addShortText() and createSummary(), but failed to; are the Groovy Postbuild plugin and jenkins-badge-plugin installed?"


### PR DESCRIPTION
Some time ago Jenkins core moved from resolution-dependent renditions of png/gif icons to svg, so the previously used URLs lead nowhere. This PR updates the codebase to use newly existing pathnames in `createSummary()` calls.

Tested as part of https://ci.networkupstools.org/view/all/job/nut/job/nut/job/FTY/9/ (compare to https://ci.networkupstools.org/view/all/job/nut/job/nut/job/FTY/8 e.g. in the end of summary page, with empty squares for icons).