### PR TITLE
Basic fixes for issue #19

### DIFF
--- a/src/org/nut/dynamatrix/Dynamatrix.groovy
+++ b/src/org/nut/dynamatrix/Dynamatrix.groovy
@@ -2515,6 +2515,12 @@ def parallelStages = prepareDynamatrix(
                     // TODO // } catch (hudson.plugins.git.GitException gex) { // see https://github.com/networkupstools/jenkins-dynamatrix/issues/19 about evil force-pushes
                     } catch (Throwable t) {
                         dsbc.thisDynamatrix?.countStagesIncrement('DEBUG-EXC-UNKNOWN: ' + Utils.castString(t), stageName + sbName)
+
+                        // No idea what happened (that's for devops to research), but this
+                        // stage has definitely completed, and not in a successful fashion....
+                        dsbc.thisDynamatrix?.countStagesIncrement('COMPLETED', stageName + sbName)
+                        dsbc.thisDynamatrix?.countStagesIncrement('FAILURE', stageName + sbName)
+
                         dsbc.thisDynamatrix?.updateProgressBadge(false, rememberClones)
                         dsbc.dsbcResultInterim = 'Throwable'
 

--- a/src/org/nut/dynamatrix/Dynamatrix.groovy
+++ b/src/org/nut/dynamatrix/Dynamatrix.groovy
@@ -2512,6 +2512,7 @@ def parallelStages = prepareDynamatrix(
                         dsbc.thisDynamatrix?.updateProgressBadge(false, rememberClones)
                         printStackTraceStderrOptional(jlie)
                         throw jlie
+                    // TODO // } catch (hudson.plugins.git.GitException gex) { // see https://github.com/networkupstools/jenkins-dynamatrix/issues/19 about evil force-pushes
                     } catch (Throwable t) {
                         dsbc.thisDynamatrix?.countStagesIncrement('DEBUG-EXC-UNKNOWN: ' + Utils.castString(t), stageName + sbName)
                         dsbc.thisDynamatrix?.updateProgressBadge(false, rememberClones)


### PR DESCRIPTION
Alleviates: #19

Now unclassified problems should be accounted better.

This PR does not add handling for different behavior if a GitException fails the build, that would be a separate effort.