### PR TITLE
Update from Fightwarn GitHub notifications branch

### DIFF
--- a/src/org/nut/dynamatrix/Dynamatrix.groovy
+++ b/src/org/nut/dynamatrix/Dynamatrix.groovy
@@ -2632,6 +2632,7 @@ def parallelStages = prepareDynamatrix(
 
                 parstageCode = {
                     def parstageCompleted = false
+                    String buildArtifactUrlPrefixSlashed = "${env.BUILD_URL?.replaceLast('/', '')}/artifact/"
                     while (!parstageCompleted) {
                         try {
                             if (enableDebugSysprint)
@@ -2670,7 +2671,7 @@ def parallelStages = prepareDynamatrix(
                                         String msg = "'slow build' stage for ${MATRIX_TAG} did not pass: ${dsbc.dsbcResultInterim}"
                                         script.infra.reportGithubStageStatus(dynacfgOrig.get("stashnameSrc"),  // TODO: Fix into DSBC copy of dynacfg for mixed-config jobs?
                                                 msg, 'FAILURE', "slowbuild-run/${MATRIX_TAG}",
-                                                dsbc.getLatestDsbcResultLog())
+                                                buildArtifactUrlPrefixSlashed + dsbc.getLatestDsbcResultLog())
                                         parstageCompleted = true
                                     }
                                     break
@@ -2722,7 +2723,7 @@ def parallelStages = prepareDynamatrix(
                                         script.infra.reportGithubStageStatus(dynacfgOrig.get("stashnameSrc"),  // TODO: Fix into DSBC copy of dynacfg for mixed-config jobs?
                                                 "'slow build' stage for ${MATRIX_TAG} did not pass: ${dsbc.dsbcResultInterim}",
                                                 'FAILURE', "slowbuild-run/${MATRIX_TAG}",
-                                                dsbc.getLatestDsbcResultLog())
+                                                buildArtifactUrlPrefixSlashed + dsbc.getLatestDsbcResultLog())
                                     }
 
                                     parstageCompleted = true
@@ -2745,7 +2746,7 @@ def parallelStages = prepareDynamatrix(
                                                 "'slow build' stage for ${MATRIX_TAG} finished somehow " +
                                                 "with unexpected verdict: ${dsbc.dsbcResultInterim}",
                                                 'FAILURE', "slowbuild-run/${MATRIX_TAG}",
-                                                dsbc.getLatestDsbcResultLog())
+                                                buildArtifactUrlPrefixSlashed + dsbc.getLatestDsbcResultLog())
                                     }
 
                                     parstageCompleted = true
@@ -2762,7 +2763,7 @@ def parallelStages = prepareDynamatrix(
                                             "'slow build' stage for ${MATRIX_TAG} finished " +
                                             "with abortion verdict: ${dsbc.dsbcResultInterim}",
                                             'FAILURE', "slowbuild-run/${MATRIX_TAG}",
-                                            dsbc.getLatestDsbcResultLog())
+                                            buildArtifactUrlPrefixSlashed + dsbc.getLatestDsbcResultLog())
 
                                     parstageCompleted = true
                                     break
@@ -2788,7 +2789,7 @@ def parallelStages = prepareDynamatrix(
                                             "'slow build' stage for ${MATRIX_TAG} finished " +
                                             "with unclassified verdict: ${dsbc.dsbcResultInterim}",
                                             'FAILURE', "slowbuild-run/${MATRIX_TAG}",
-                                            dsbc.getLatestDsbcResultLog())
+                                            buildArtifactUrlPrefixSlashed + dsbc.getLatestDsbcResultLog())
 
                                     // DO NOT continue to loop
                                     parstageCompleted = true

--- a/src/org/nut/dynamatrix/Dynamatrix.groovy
+++ b/src/org/nut/dynamatrix/Dynamatrix.groovy
@@ -2632,7 +2632,6 @@ def parallelStages = prepareDynamatrix(
 
                 parstageCode = {
                     def parstageCompleted = false
-                    String buildArtifactUrlPrefixSlashed = "${env.BUILD_URL?.replaceLast('/', '')}/artifact/"
                     while (!parstageCompleted) {
                         try {
                             if (enableDebugSysprint)
@@ -2671,7 +2670,7 @@ def parallelStages = prepareDynamatrix(
                                         String msg = "'slow build' stage for ${MATRIX_TAG} did not pass: ${dsbc.dsbcResultInterim}"
                                         script.infra.reportGithubStageStatus(dynacfgOrig.get("stashnameSrc"),  // TODO: Fix into DSBC copy of dynacfg for mixed-config jobs?
                                                 msg, 'FAILURE', "slowbuild-run/${MATRIX_TAG}",
-                                                buildArtifactUrlPrefixSlashed + dsbc.getLatestDsbcResultLog())
+                                                dsbc.getLatestDsbcResultLogUrl())
                                         parstageCompleted = true
                                     }
                                     break
@@ -2723,7 +2722,7 @@ def parallelStages = prepareDynamatrix(
                                         script.infra.reportGithubStageStatus(dynacfgOrig.get("stashnameSrc"),  // TODO: Fix into DSBC copy of dynacfg for mixed-config jobs?
                                                 "'slow build' stage for ${MATRIX_TAG} did not pass: ${dsbc.dsbcResultInterim}",
                                                 'FAILURE', "slowbuild-run/${MATRIX_TAG}",
-                                                buildArtifactUrlPrefixSlashed + dsbc.getLatestDsbcResultLog())
+                                                dsbc.getLatestDsbcResultLogUrl())
                                     }
 
                                     parstageCompleted = true
@@ -2746,7 +2745,7 @@ def parallelStages = prepareDynamatrix(
                                                 "'slow build' stage for ${MATRIX_TAG} finished somehow " +
                                                 "with unexpected verdict: ${dsbc.dsbcResultInterim}",
                                                 'FAILURE', "slowbuild-run/${MATRIX_TAG}",
-                                                buildArtifactUrlPrefixSlashed + dsbc.getLatestDsbcResultLog())
+                                                dsbc.getLatestDsbcResultLogUrl())
                                     }
 
                                     parstageCompleted = true
@@ -2763,7 +2762,7 @@ def parallelStages = prepareDynamatrix(
                                             "'slow build' stage for ${MATRIX_TAG} finished " +
                                             "with abortion verdict: ${dsbc.dsbcResultInterim}",
                                             'FAILURE', "slowbuild-run/${MATRIX_TAG}",
-                                            buildArtifactUrlPrefixSlashed + dsbc.getLatestDsbcResultLog())
+                                            dsbc.getLatestDsbcResultLogUrl())
 
                                     parstageCompleted = true
                                     break
@@ -2789,7 +2788,7 @@ def parallelStages = prepareDynamatrix(
                                             "'slow build' stage for ${MATRIX_TAG} finished " +
                                             "with unclassified verdict: ${dsbc.dsbcResultInterim}",
                                             'FAILURE', "slowbuild-run/${MATRIX_TAG}",
-                                            buildArtifactUrlPrefixSlashed + dsbc.getLatestDsbcResultLog())
+                                            dsbc.getLatestDsbcResultLogUrl())
 
                                     // DO NOT continue to loop
                                     parstageCompleted = true

--- a/src/org/nut/dynamatrix/Dynamatrix.groovy
+++ b/src/org/nut/dynamatrix/Dynamatrix.groovy
@@ -2103,15 +2103,15 @@ def parallelStages = prepareDynamatrix(
             // TODO: Fix into DSBC copy of dynacfg for mixed-config jobs?
             // NOTE: vars/prepareDynamatrix passes a null dynacfgOrig for its
             // work (to avoid further re-customizations here)!
-            String stashName = dynacfgOrig.get("stashnameSrc")
+            String stashName = dynacfgOrig?.get("stashnameSrc")
             if (stashName == null) {
                 // TODO: Parameterize the magic name (dynacfgPipeline) somehow
                 try {
-                    stashName = dynacfgPipeline.get("stashnameSrc")
+                    stashName = dynacfgPipeline?.get("stashnameSrc")
                 } catch (Throwable ignored) {}
                 if (stashName == null) {
                     try {
-                        stashName = script.dynacfgPipeline.get("stashnameSrc")
+                        stashName = this.script?.dynacfgPipeline?.get("stashnameSrc")
                     } catch (Throwable ignored) {}
                 }
                 if (stashName == null) {

--- a/src/org/nut/dynamatrix/Dynamatrix.groovy
+++ b/src/org/nut/dynamatrix/Dynamatrix.groovy
@@ -2100,6 +2100,30 @@ def parallelStages = prepareDynamatrix(
                 }
             }
 
+            // TODO: Fix into DSBC copy of dynacfg for mixed-config jobs?
+            // NOTE: vars/prepareDynamatrix passes a null dynacfgOrig for its
+            // work (to avoid further re-customizations here)!
+            String stashName = dynacfgOrig.get("stashnameSrc")
+            if (stashName == null) {
+                // TODO: Parameterize the magic name (dynacfgPipeline) somehow
+                try {
+                    stashName = dynacfgPipeline.get("stashnameSrc")
+                } catch (Throwable ignored) {}
+                if (stashName == null) {
+                    try {
+                        stashName = script.dynacfgPipeline.get("stashnameSrc")
+                    } catch (Throwable ignored) {}
+                }
+                if (stashName == null) {
+                    try {
+                        Closure x = {return dynacfgPipeline.get("stashnameSrc")}
+                        x = x.dehydrate().rehydrate([:], this.script, this.script)
+                        x.resolveStrategy = Closure.DELEGATE_FIRST
+                        stashName = x.call()
+                    } catch (Throwable ignored) {}
+                }
+            }
+
             if (debugMilestonesDetails
             //|| debugMilestones
             //|| debugTrace
@@ -2586,8 +2610,7 @@ def parallelStages = prepareDynamatrix(
                         if (dsbc.thisDynamatrix) {
                             dsbc.thisDynamatrix.updateProgressBadge(false, rememberClones)
                             if (dsbc.thisDynamatrix.reportPrefixCountStagesExpected != null) {
-                                script.infra.reportGithubStageStatus(
-                                        dynacfgOrig.get("stashnameSrc"),  // TODO: Fix into DSBC copy of dynacfg for mixed-config jobs?
+                                script.infra.reportGithubStageStatus(stashName,
                                         dsbc.thisDynamatrix.reportPrefixCountStagesExpected + ": " +
                                         dsbc.thisDynamatrix.toStringStageCountBestEffort().replaceAll("countStages", ""),
                                         "PENDING",
@@ -2668,7 +2691,7 @@ def parallelStages = prepareDynamatrix(
                                         }
 
                                         String msg = "'slow build' stage for ${MATRIX_TAG} did not pass: ${dsbc.dsbcResultInterim}"
-                                        script.infra.reportGithubStageStatus(dynacfgOrig.get("stashnameSrc"),  // TODO: Fix into DSBC copy of dynacfg for mixed-config jobs?
+                                        script.infra.reportGithubStageStatus(stashName,
                                                 msg, 'FAILURE', "slowbuild-run/${MATRIX_TAG}",
                                                 dsbc.getLatestDsbcResultLogUrl())
                                         parstageCompleted = true
@@ -2719,7 +2742,7 @@ def parallelStages = prepareDynamatrix(
                                         "Throwable was caught: ${Utils.castString(t)}"
 
                                     if (!(dsbc.dsbcResultInterim in [null, 'SUCCESS'])) {
-                                        script.infra.reportGithubStageStatus(dynacfgOrig.get("stashnameSrc"),  // TODO: Fix into DSBC copy of dynacfg for mixed-config jobs?
+                                        script.infra.reportGithubStageStatus(stashName,
                                                 "'slow build' stage for ${MATRIX_TAG} did not pass: ${dsbc.dsbcResultInterim}",
                                                 'FAILURE', "slowbuild-run/${MATRIX_TAG}",
                                                 dsbc.getLatestDsbcResultLogUrl())
@@ -2741,7 +2764,7 @@ def parallelStages = prepareDynamatrix(
                                         "Throwable was caught: ${Utils.castString(t)}"
 
                                     if (!(dsbc.dsbcResultInterim in ['STARTED', 'RESTARTED', 'COMPLETED', 'ABORTED_SAFE'])) {
-                                        script.infra.reportGithubStageStatus(dynacfgOrig.get("stashnameSrc"),  // TODO: Fix into DSBC copy of dynacfg for mixed-config jobs?
+                                        script.infra.reportGithubStageStatus(stashName,
                                                 "'slow build' stage for ${MATRIX_TAG} finished somehow " +
                                                 "with unexpected verdict: ${dsbc.dsbcResultInterim}",
                                                 'FAILURE', "slowbuild-run/${MATRIX_TAG}",
@@ -2758,7 +2781,7 @@ def parallelStages = prepareDynamatrix(
                                         "'${dsbc.dsbcResultInterim}' and a " +
                                         "Throwable was caught: ${Utils.castString(t)}"
 
-                                    script.infra.reportGithubStageStatus(dynacfgOrig.get("stashnameSrc"),  // TODO: Fix into DSBC copy of dynacfg for mixed-config jobs?
+                                    script.infra.reportGithubStageStatus(stashName,
                                             "'slow build' stage for ${MATRIX_TAG} finished " +
                                             "with abortion verdict: ${dsbc.dsbcResultInterim}",
                                             'FAILURE', "slowbuild-run/${MATRIX_TAG}",
@@ -2784,7 +2807,7 @@ def parallelStages = prepareDynamatrix(
                                         "aborting the stage-running loop; a " +
                                         "Throwable was caught: ${Utils.castString(t)}"
 
-                                    script.infra.reportGithubStageStatus(dynacfgOrig.get("stashnameSrc"),  // TODO: Fix into DSBC copy of dynacfg for mixed-config jobs?
+                                    script.infra.reportGithubStageStatus(stashName,
                                             "'slow build' stage for ${MATRIX_TAG} finished " +
                                             "with unclassified verdict: ${dsbc.dsbcResultInterim}",
                                             'FAILURE', "slowbuild-run/${MATRIX_TAG}",

--- a/src/org/nut/dynamatrix/DynamatrixSingleBuildConfig.groovy
+++ b/src/org/nut/dynamatrix/DynamatrixSingleBuildConfig.groovy
@@ -299,7 +299,9 @@ class DynamatrixSingleBuildConfig implements Cloneable {
      *  matrix-cell step, for notifications to be even more relevant.
      *
      * @return  Filename of the log. Caller should prepend the
-     *          build artifact location etc. to make an URL of it.
+     *          build artifact location etc. to make an URL of
+     *          it, with a prefix like this:
+     *          <pre>String buildArtifactUrlPrefixSlashed = env.BUILD_URL?.replaceLast('/', '') + "/artifact/"</pre>
      */
     @NonCPS
     String getLatestDsbcResultLog() {
@@ -311,6 +313,22 @@ class DynamatrixSingleBuildConfig implements Cloneable {
             }
         }
         return s
+    }
+
+    /**
+     * Returns an URL to expected artifact with the log per
+     * {@link #getLatestDsbcResultLog} or null in case of
+     * problems resolving some sub-strings for such URL.
+     * @return String (URL or null)
+     */
+    @NonCPS
+    String getLatestDsbcResultLogUrl() {
+        String buildUrl = this.script?.env?.BUILD_URL
+        String logFile = getLatestDsbcResultLog()
+        if (Utils.isStringNotEmpty(buildUrl) && Utils.isStringNotEmpty(logFile)) {
+            return buildUrl.replaceLast('/', '') + "/artifact/" + logFile
+        }
+        return null
     }
 
     /**

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -205,7 +205,7 @@ def reportGithubStageStatus(def stashName, String message, String state, String 
             }
             if (scmVars == null) {
                 stashNameUsed = stashName
-                scmVars = DynamatrixStash.getSCMVarsstashNameUsed)
+                scmVars = DynamatrixStash.getSCMVars(stashNameUsed)
             }
             String scmCommit = scmVars?.GIT_COMMIT
             String scmURL = scmVars?.GIT_URL

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -399,7 +399,7 @@ def reportGithubStageStatus(def stashName, String message, String state, String 
                         scmVars[scmVarsKey] = [:]
                     }
                     scmVars[scmVarsKey].GIT_COMMIT = scmCommit
-                    scmVars[scmVarsKey].GIT_URL = scmUrl
+                    scmVars[scmVarsKey].GIT_URL = scmURL
                     stashNameUsed = scmVarsKey
                 }
             }

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -205,8 +205,8 @@ def reportGithubStageStatus(def stashName, String message, String state, String 
                 stashNameUsed = stashName
                 scmVars = DynamatrixStash.getSCMVarsstashNameUsed)
             }
-            def scmCommit = scmVars?.GIT_COMMIT
-            def scmURL = scmVars?.GIT_URL
+            String scmCommit = scmVars?.GIT_COMMIT
+            String scmURL = scmVars?.GIT_URL
 
             // Most of the time cached info is present, except
             // early in the job run - while the git checkout

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -179,7 +179,7 @@ def reportGithubStageStatus(def stashName, String message, String state, String 
     if (dynamatrixGlobalState.enableDebugTraceGithubStatusHighlights
     || (dynamatrixGlobalState.enableDebugTrace && dynamatrixGlobalState.enableDebugTraceGithubStatusHighlights != false)
     ) {
-        echo "[DEBUG] reportGithubStageStatus called; dynamatrixGlobalState.enableGithubStatusHighlights=${dynamatrixGlobalState.enableGithubStatusHighlights}, stashName=${stashName}, message=${message}, state=${state}, messageContext=${messageContext}"
+        echo "[DEBUG] reportGithubStageStatus called; dynamatrixGlobalState.enableGithubStatusHighlights=${dynamatrixGlobalState.enableGithubStatusHighlights}, stashName=${stashName}, message=${message}, state=${state}, messageContext=${messageContext}, backrefUrl=${backrefUrl}"
     }
 
     if (dynamatrixGlobalState.enableGithubStatusHighlights) {

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -176,9 +176,12 @@ Set<String> listChangedFiles() {
  * sources. See also https://docs.github.com/rest/commits/statuses#create-a-commit-status
  */
 def reportGithubStageStatus(def stashName, String message, String state, String messageContext = null, String backrefUrl = null) {
-    if (dynamatrixGlobalState.enableDebugTraceGithubStatusHighlights
-    || (dynamatrixGlobalState.enableDebugTrace && dynamatrixGlobalState.enableDebugTraceGithubStatusHighlights != false)
-    ) {
+    boolean doDebug = (
+            dynamatrixGlobalState.enableDebugTraceGithubStatusHighlights
+            || (dynamatrixGlobalState.enableDebugTrace && dynamatrixGlobalState.enableDebugTraceGithubStatusHighlights != false)
+    )
+
+    if (doDebug) {
         echo "[DEBUG] reportGithubStageStatus called; dynamatrixGlobalState.enableGithubStatusHighlights=${dynamatrixGlobalState.enableGithubStatusHighlights}, stashName=${stashName}, message=${message}, state=${state}, messageContext=${messageContext}, backrefUrl=${backrefUrl}"
     }
 
@@ -218,6 +221,10 @@ def reportGithubStageStatus(def stashName, String message, String state, String 
                 SCMSource src = SCMSource.SourceByItem.findSource(currentBuild.rawBuild.getParent());
                 SCMRevision revision = (src != null ? SCMRevisionAction.getRevision(src, currentBuild.rawBuild) : null);
 
+                if (doDebug) {
+                    echo ("[DEBUG] reportGithubStageStatus discovering from SCMSource=${Utils.castString(src)} and SCMRevision=${Utils.castString(revision)}")
+                }
+
                 if (src != null && revision != null
                 && revision instanceof PullRequestSCMRevision
                 && src instanceof GitHubSCMSource
@@ -236,6 +243,10 @@ def reportGithubStageStatus(def stashName, String message, String state, String 
 
             if (scmURL == null && scm != null && scm instanceof GitSCM) {
                 for(UserRemoteConfig c : scm.getUserRemoteConfigs()) {
+                    if (doDebug) {
+                        echo ("[DEBUG] reportGithubStageStatus discovering from scm.getUserRemoteConfigs()): ${Utils.castString(c)}")
+                    }
+
                     if (!("dynamatrix" in c.getUrl())) {
                         scmURL = c.getUrl()
                         //scmCommit = ... ?
@@ -306,9 +317,7 @@ def reportGithubStageStatus(def stashName, String message, String state, String 
             if (Utils.isStringNotEmpty(backrefUrl))
                 stepArgs['statusBackrefSource'] = [$class: "ManuallyEnteredBackrefSource", backref: backrefUrl]
 
-            if (dynamatrixGlobalState.enableDebugTraceGithubStatusHighlights
-            || (dynamatrixGlobalState.enableDebugTrace && dynamatrixGlobalState.enableDebugTraceGithubStatusHighlights != false)
-            ) {
+            if (doDebug) {
                 echo "[DEBUG] reportGithubStageStatus() with GitHubCommitStatusSetter step:\n\t" +
                         "stashName=${Utils.castString(stashName)}\n\t" +
                         "stashNameUsed=${Utils.castString(stashNameUsed)}\n\t" +
@@ -322,9 +331,7 @@ def reportGithubStageStatus(def stashName, String message, String state, String 
         } catch (Throwable t) {
             echo "WARNING: Tried to use GitHubCommitStatusSetter but got an exception; is github-plugin installed and configured?"
 
-            if (dynamatrixGlobalState.enableDebugTraceGithubStatusHighlights
-            || (dynamatrixGlobalState.enableDebugTrace && dynamatrixGlobalState.enableDebugTraceGithubStatusHighlights != false)
-            ) {
+            if (doDebug) {
                 echo t.toString()
             }
         }

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -214,6 +214,29 @@ def reportGithubStageStatus(def stashName, String message, String state, String 
             // The cached SCMVars only become known after the
             // appearance of that git workspace, but we send
             // some statuses before that.
+/*
+    // INVESTIGATION HACKS
+    def j = Jenkins.instance.getItemByFullName("nut/nut/fightwarn")
+    println "job: ${j}"
+    def build = j.getBuildByNumber(117)
+
+    println build
+
+    def commitHashForBuild(build) {
+      def scmAction = null
+      build?.actions.each { action ->
+        println "action: <${action?.getClass()}>'${action}'"
+        if (action instanceof jenkins.scm.api.SCMRevisionAction)
+            scmAction = action
+      }
+      println "scmAction: <${scmAction?.getClass()}>'${scmAction}'"
+      println "scmAction.revision: <${scmAction?.revision?.getClass()}>'${scmAction?.revision}'"
+      println "scmAction.revision.hash: <${scmAction?.revision?.hash?.getClass()}>'${scmAction?.revision?.hash}'"
+      return scmAction?.revision?.hash
+    }
+
+    println commitHashForBuild(build)
+*/
             if (scmVars == null) {
                 // At least if there's just one SCMSource attached
                 // to the job definition, we can do this (TOCHECK:
@@ -257,6 +280,14 @@ def reportGithubStageStatus(def stashName, String message, String state, String 
             if (scmCommit == null) {
                 scmCommit = env?.GIT_COMMIT
             }
+
+/*
+            // TODO: consider pr/1979/head or pull/1979/head - note
+            //  this may march on while the build is running?
+            if (scmCommit == null && env?.BRANCH_NAME ==~ /^PR-[0-9]+$/ ) {
+                scmCommit = env?.GIT_COMMIT
+            }
+*/
 
             if (scmURL == null) {
                 scmURL = env?.GIT_URL

--- a/vars/infra.groovy
+++ b/vars/infra.groovy
@@ -184,6 +184,7 @@ def reportGithubStageStatus(def stashName, String message, String state, String 
 
     if (dynamatrixGlobalState.enableGithubStatusHighlights) {
         try {
+            String stashNameUsed = null
             Map scmVars = null
             // If this was a first report before/during checkout, so info about
             // it was not stashed yet and we had to discover git information
@@ -193,10 +194,14 @@ def reportGithubStageStatus(def stashName, String message, String state, String 
             // other development), and the actual stashed info about the git
             // workspace checked out and recorded would have a tip commit hash
             // unknown to github. So we actually prefer that info if available.
-            if (stashName != null)
-                scmVars = DynamatrixStash.getSCMVars(stashName + ":reportGithubStageStatus-orig")
-            if (scmVars == null)
-                scmVars = DynamatrixStash.getSCMVars(stashName)
+            if (stashName != null) {
+                stashNameUsed = stashName + ":reportGithubStageStatus-orig"
+                scmVars = DynamatrixStash.getSCMVars(stashNameUsed)
+            }
+            if (scmVars == null) {
+                stashNameUsed = stashName
+                scmVars = DynamatrixStash.getSCMVarsstashNameUsed)
+            }
             def scmCommit = scmVars?.GIT_COMMIT
             def scmURL = scmVars?.GIT_URL
 
@@ -285,6 +290,7 @@ def reportGithubStageStatus(def stashName, String message, String state, String 
                     }
                     scmVars[scmVarsKey].GIT_COMMIT = scmCommit
                     scmVars[scmVarsKey].GIT_URL = scmUrl
+                    stashNameUsed = scmVarsKey
                 }
             }
 
@@ -305,6 +311,7 @@ def reportGithubStageStatus(def stashName, String message, String state, String 
             ) {
                 echo "[DEBUG] reportGithubStageStatus() with GitHubCommitStatusSetter step:\n\t" +
                         "stashName=${Utils.castString(stashName)}\n\t" +
+                        "stashNameUsed=${Utils.castString(stashNameUsed)}\n\t" +
                         "scmVars=${Utils.castString(scmVars)}\n\t" +
                         "scmURL=${Utils.castString(scmURL)}\n\t" +
                         "scmCommit=${Utils.castString(scmCommit)}\n\t" +


### PR DESCRIPTION
Follows up on recent work with smoother github notifications. Should fix backreference URLs to failures (lead to latest sub-stage log file), and fix detection of suitable commit hash to report into with several fallbacks and a different config passing mechanism.