### PR TITLE
Faster shared lock

### DIFF
--- a/src/org/nut/dynamatrix/Dynamatrix.groovy
+++ b/src/org/nut/dynamatrix/Dynamatrix.groovy
@@ -492,6 +492,14 @@ class Dynamatrix implements Cloneable {
         return res
     }
 
+    /** Pretty string like {@code "quick test"} (if
+     *  {@link #dynamatrixGithubNotificationContext}
+     *  is {@code "quickbuild-run"},
+     *  or {@code "slow build"} otherwise. */
+    String getBuildTypeFromGHNContext() {
+        return (this.dynamatrixGithubNotificationContext == "quickbuild-run") ? "quick test" : "slow build"
+    }
+
     /**
      * Roll a text entry in the "yellow boxes" of the left column (job build
      * current+history list) in the classic Jenkins user interface - page for
@@ -2773,7 +2781,7 @@ def parallelStages = prepareDynamatrix(
                                         // Calculated above in this method.
                                         // Or try variant from buildMatrixCellCI:
                                         String MATRIX_TAG = Utils.prepare_MATRIX_TAG(matrixTag, stageName)
-                                        String buildType = (this.dynamatrixGithubNotificationContext == "quickbuild-run") ? "quick test" : "slow build"
+                                        String buildType = this.getBuildTypeFromGHNContext()
                                         String msg = "'${buildType}' stage for ${MATRIX_TAG} passed after re-run: ${dsbc.dsbcResultInterim}"
                                         // Only actually report if this context was previously
                                         // known by GitHub (as any state)
@@ -2791,7 +2799,7 @@ def parallelStages = prepareDynamatrix(
                                         // Or try variant from buildMatrixCellCI:
                                         String MATRIX_TAG = Utils.prepare_MATRIX_TAG(matrixTag, stageName)
 
-                                        String buildType = (this.dynamatrixGithubNotificationContext == "quickbuild-run") ? "quick test" : "slow build"
+                                        String buildType = this.getBuildTypeFromGHNContext()
                                         String msg = "'${buildType}' stage for ${MATRIX_TAG} did not pass: ${dsbc.dsbcResultInterim}"
                                         script.infra.reportGithubStageStatus(stashName,
                                                 msg,
@@ -2842,7 +2850,7 @@ def parallelStages = prepareDynamatrix(
                                     if (!(dsbc.dsbcResultInterim in [null, 'SUCCESS']) && !(Utils.isRetryableException(t))) {
                                         // Retryable: are shellcheck retried faults in this reporting category or above?
                                         try {
-                                            String buildType = (this.dynamatrixGithubNotificationContext == "quickbuild-run") ? "quick test" : "slow build"
+                                            String buildType = this.getBuildTypeFromGHNContext()
                                             script.infra.reportGithubStageStatus(stashName,
                                                 "'${buildType}' stage for ${MATRIX_TAG} did not pass: ${dsbc.dsbcResultInterim}",
                                                 'FAILURE', "${this.dynamatrixGithubNotificationContext}/${MATRIX_TAG}",
@@ -2876,7 +2884,7 @@ def parallelStages = prepareDynamatrix(
 
                                     if (!(dsbc.dsbcResultInterim in ['STARTED', 'RESTARTED', 'COMPLETED', 'ABORTED_SAFE'])) {
                                         try {
-                                            String buildType = (this.dynamatrixGithubNotificationContext == "quickbuild-run") ? "quick test" : "slow build"
+                                            String buildType = this.getBuildTypeFromGHNContext()
                                             script.infra.reportGithubStageStatus(stashName,
                                                 "'${buildType}' stage for ${MATRIX_TAG} finished somehow " +
                                                 "with unexpected verdict: ${dsbc.dsbcResultInterim}",
@@ -2898,7 +2906,7 @@ def parallelStages = prepareDynamatrix(
                                         "Throwable was caught: ${Utils.castString(t)}"
 
                                     try {
-                                        String buildType = (this.dynamatrixGithubNotificationContext == "quickbuild-run") ? "quick test" : "slow build"
+                                        String buildType = this.getBuildTypeFromGHNContext()
                                         script.infra.reportGithubStageStatus(stashName,
                                             "'${buildType}' stage for ${MATRIX_TAG} finished " +
                                             "with abortion verdict: ${dsbc.dsbcResultInterim}",
@@ -2929,7 +2937,7 @@ def parallelStages = prepareDynamatrix(
                                         "Throwable was caught: ${Utils.castString(t)}"
 
                                     try {
-                                        String buildType = (this.dynamatrixGithubNotificationContext == "quickbuild-run") ? "quick test" : "slow build"
+                                        String buildType = this.getBuildTypeFromGHNContext()
                                         script.infra.reportGithubStageStatus(stashName,
                                             "'${buildType}' stage for ${MATRIX_TAG} finished " +
                                             "with unclassified verdict: ${dsbc.dsbcResultInterim}",

--- a/src/org/nut/dynamatrix/Dynamatrix.groovy
+++ b/src/org/nut/dynamatrix/Dynamatrix.groovy
@@ -44,6 +44,8 @@ class Dynamatrix implements Cloneable {
     /** Have some defaults, if only to have all expected fields defined */
     private DynamatrixConfig dynacfgSaved = null
     /** Have some defaults, if only to have all expected fields defined */
+    private String dynamatrixGithubNotificationContextSaved = null
+    /** Have some defaults, if only to have all expected fields defined */
     private def script
     /** Prepared String with identifier of this object */
     private final String objectID = Integer.toHexString(hashCode())
@@ -666,6 +668,7 @@ class Dynamatrix implements Cloneable {
     public boolean saveDynacfg() {
         this.dynacfgSaved = null // GC
         this.dynacfgSaved = this.dynacfg.clone()
+        this.dynamatrixGithubNotificationContextSaved = this.dynamatrixGithubNotificationContext
         return true
     }
 
@@ -677,6 +680,7 @@ class Dynamatrix implements Cloneable {
         if (this.dynacfgSaved != null) {
             this.dynacfg = null // GC
             this.dynacfg = this.dynacfgSaved.clone()
+            this.dynamatrixGithubNotificationContext = this.dynamatrixGithubNotificationContextSaved
             return true
         }
         return false

--- a/src/org/nut/dynamatrix/DynamatrixStash.groovy
+++ b/src/org/nut/dynamatrix/DynamatrixStash.groovy
@@ -726,7 +726,7 @@ echo "[DEBUG] Files in `pwd`: `find . -type f | wc -l` and all FS objects under:
 
         // TODO: Less shell-scripting below, more groovy, to alleviate this:
         if (!script.isUnix()) {
-            script.echo "checkoutCleanSrcRefrepoWS: node '${script?.env?.NODE_NAME}' is not Unix (can't shell-script git), falling back"
+            script.echo "checkoutCleanSrcRefrepoWS: node '${script?.env?.NODE_NAME}': is not Unix (can't shell-script git), falling back"
             return false
         }
 
@@ -744,7 +744,7 @@ echo "[DEBUG] Files in `pwd`: `find . -type f | wc -l` and all FS objects under:
                 scmURL    = stashSCMVars[stashName]?.GIT_URL
             }
 
-            script.echo "checkoutCleanSrcRefrepoWS: on node '${script?.env?.NODE_NAME}' checking refrepo for '${stashName}'"
+            script.echo "checkoutCleanSrcRefrepoWS: on node '${script?.env?.NODE_NAME}': checking refrepo for '${stashName}'"
             //script.sh "hostname; set | sort -n"
             if (scm instanceof GitSCM) {
                 // GitSCM object
@@ -831,7 +831,7 @@ echo "[DEBUG] Files in `pwd`: `find . -type f | wc -l` and all FS objects under:
                 lockName = 'gitcache-dynamatrix:defaultLock'
             }
 
-            script.echo "[DEBUG] checkoutCleanSrcRefrepoWS: node '${script?.env?.NODE_NAME}' waiting for exclusive use (${lockName}) of git cache dir to check out: repo '${scmURL}' commit '${scmCommit}'"
+            script.echo "[DEBUG] checkoutCleanSrcRefrepoWS: node '${script?.env?.NODE_NAME}': waiting for exclusive use (${lockName}) of git cache dir to check out: repo '${scmURL}' commit '${scmCommit}'"
             script.lock (resource: lockName, quantity: 1) {
                 // NOTE: Currently this means one lock for all git ops of the CI
                 // farm per hypervisor via DYNAMATRIX_REFREPO_WORKSPACE_LOCKNAME
@@ -875,7 +875,7 @@ echo "[DEBUG] Files in `pwd`: `find . -type f | wc -l` and all FS objects under:
                 script.echo "[DEBUG] checkoutCleanSrcRefrepoWS: node '${script?.env?.NODE_NAME}': determined individual refrepo dir path: '" + refrepoBase + "'/'" + refrepoName + "'"
                 script.dir (refrepoBase + "/" + refrepoName) {
                     refrepoPath = script.pwd()
-                    script.echo "[DEBUG] checkoutCleanSrcRefrepoWS: node '${script?.env?.NODE_NAME}' exclusively using git cache dir ${refrepoPath}"
+                    script.echo "[DEBUG] checkoutCleanSrcRefrepoWS: node '${script?.env?.NODE_NAME}': exclusively using git cache dir ${refrepoPath}"
 
                     // Update (maybe init) the refrepo dir itself
                     // (currently does not use git-plugin so does not really

--- a/src/org/nut/dynamatrix/DynamatrixStash.groovy
+++ b/src/org/nut/dynamatrix/DynamatrixStash.groovy
@@ -404,22 +404,28 @@ class DynamatrixStash {
     } // cloneSCM()
 
     /** Variant of {@code checkoutCleanSrc()} with {@code scmCommit=null}
-     *  and {@code untieRefrepoNow=true}.
-     *  @see #checkoutCleanSrc(Object, String, String, Boolean, Closure) */
+     *  and {@code untieRefrepoNow=true} and {@code requestDeleteWS=true}.
+     *  @see #checkoutCleanSrc(Object, String, String, Boolean, Boolean, Closure) */
     static def checkoutCleanSrc(def script, String stashName, Closure scmbody) {
-        return checkoutCleanSrc(script, stashName, null, true, scmbody)
+        return checkoutCleanSrc(script, stashName, null, true, true, scmbody)
     } // checkoutCleanSrc() wrapper
 
-    /** Variant of {@code checkoutCleanSrc()} with {@code untieRefrepoNow=true}.
-     *  @see #checkoutCleanSrc(Object, String, String, Boolean, Closure) */
+    /** Variant of {@code checkoutCleanSrc()} with {@code untieRefrepoNow=true} and {@code requestDeleteWS=true}.
+     *  @see #checkoutCleanSrc(Object, String, String, Boolean, Boolean, Closure) */
     static def checkoutCleanSrc(def script, String stashName, String scmCommit, Closure scmbody) {
-        return checkoutCleanSrc(script, stashName, scmCommit, true, scmbody)
+        return checkoutCleanSrc(script, stashName, scmCommit, true, true, scmbody)
     } // checkoutCleanSrc() wrapper
 
-    /** Variant of {@code checkoutCleanSrc()} with {@code scmCommit=null}.
-     *  @see #checkoutCleanSrc(Object, String, String, Boolean, Closure) */
+    /** Variant of {@code checkoutCleanSrc()} with {@code scmCommit=null} and {@code requestDeleteWS=true}.
+     *  @see #checkoutCleanSrc(Object, String, String, Boolean, Boolean, Closure) */
     static def checkoutCleanSrc(def script, String stashName, Boolean untieRefrepoNow, Closure scmbody) {
-        return checkoutCleanSrc(script, stashName, null, untieRefrepoNow, scmbody)
+        return checkoutCleanSrc(script, stashName, null, untieRefrepoNow, true, scmbody)
+    } // checkoutCleanSrc() wrapper
+
+    /** Variant of {@code checkoutCleanSrc()} with {@code requestDeleteWS=true}.
+     *  @see #checkoutCleanSrc(Object, String, String, Boolean, Boolean, Closure) */
+    static def checkoutCleanSrc(def script, String stashName, String scmCommit, Boolean untieRefrepoNow, Closure scmbody) {
+        return checkoutCleanSrc(script, stashName, scmCommit, untieRefrepoNow, true, scmbody)
     } // checkoutCleanSrc() wrapper
 
     /**
@@ -438,8 +444,19 @@ class DynamatrixStash {
      * @see #checkoutCleanSrcNamed
      * @see #checkoutCleanSrcRefrepoWS
      */
-    static def checkoutCleanSrc(def script, String stashName = null, String scmCommit = null, Boolean untieRefrepoNow = true, Closure scmbody = null) {
-        deleteWS(script)
+    static def checkoutCleanSrc(
+        def script,
+        String stashName = null,
+        String scmCommit = null,
+        Boolean untieRefrepoNow = true,
+        Boolean requestDeleteWS = true,
+        Closure scmbody = null
+    ) {
+        if (requestDeleteWS) {
+            // Can be time-consuming; best done in advance outside
+            // shared lock context of checkoutCleanSrcRefrepoWS()
+            deleteWS(script)
+        }
 
         def scm = cloneSCM(script)
         def res = null
@@ -714,7 +731,7 @@ echo "[DEBUG] Files in `pwd`: `find . -type f | wc -l` and all FS objects under:
      *
      * @see #checkoutCleanSrc(Object, String, String, Boolean, Closure)
      */
-    synchronized static def checkoutCleanSrcRefrepoWS(def script, String stashName) {
+    synchronized static def checkoutCleanSrcRefrepoWS(def script, String stashName, Boolean requestDeleteWS = true) {
         def scm = cloneSCM(script)
 
         if (!(Utils.isMap(scm)
@@ -965,7 +982,7 @@ exit \$RET
                         // "false" says to not "untie" refrepo in the build agent;
                         // we only request specific scmCommit if it is a known Git
                         // SHA hash (not a symbolic branch/tag/PR/... name):
-                        ret = checkoutCleanSrc(script, stashName, ((scmCommit ==~ /^[0-9a-fA-F]{40}$/) ? scmCommit : null), false, stashCode[stashName])
+                        ret = checkoutCleanSrc(script, stashName, ((scmCommit ==~ /^[0-9a-fA-F]{40}$/) ? scmCommit : null), false, requestDeleteWS, stashCode[stashName])
                     } // withEnv for checking/populating original workspace
                       // just using refrepo (if usable in the end)
                 }
@@ -1037,9 +1054,14 @@ exit \$RET
                     // using this refrepo. Use locking!
                     // Do benefit from local reference repo, if any (untie=false)
 
+                    // Can be time-consuming; best done in advance outside
+                    // shared lock context of checkoutCleanSrcRefrepoWS()
+                    deleteWS(script)
                     //script.echo "[D] unstashCleanSrc(): ${useMethod}: calling checkoutCleanSrcRefrepoWS"
-                    if (checkoutCleanSrcRefrepoWS(script, stashName) == false) {
+                    if (checkoutCleanSrcRefrepoWS(script, stashName, false) == false) {
                         script.echo "WARNING: unstashCleanSrc() asked to use 'scm-ws' but failed on node '${script?.env?.NODE_NAME}'. Falling back to 'scm'."
+                        // Note this defaults to requestDeleteWS=true so any
+                        // sins of checkoutCleanSrcRefrepoWS() are forgotten:
                         if (checkoutCleanSrc(script, stashName, false, stashCode[stashName]))
                             return
                     } else {

--- a/src/org/nut/dynamatrix/DynamatrixStash.groovy
+++ b/src/org/nut/dynamatrix/DynamatrixStash.groovy
@@ -85,6 +85,9 @@ class DynamatrixStash {
      *  (current directory!), including possible {@code @tmp}
      *  and {@code @script} satellites). */
     static void deleteWS(def script) {
+        Date start = new Date()
+        script.echo "[DEBUG] deleteWS(): clearing away '${script?.pwd()}' on '${script?.env?.NODE_NAME}' and any possible satellites - STARTING"
+
         /* clean up our workspace (current directory) */
         script.deleteDir()
 
@@ -97,6 +100,9 @@ class DynamatrixStash {
         script.dir("${script.workspace}@script") {
             script.deleteDir()
         }
+
+        Date finish = new Date()
+        script.echo "[DEBUG] deleteWS(): clearing away '${script?.pwd()}' on '${script?.env?.NODE_NAME}' and any possible satellites - FINISHED after ${((finish.getTime() - start.getTime()) / 1000)} seconds"
     } // deleteWS()
 
     /** Determine if we should use a git refrepo for this workspace

--- a/src/org/nut/dynamatrix/DynamatrixStash.groovy
+++ b/src/org/nut/dynamatrix/DynamatrixStash.groovy
@@ -113,14 +113,15 @@ class DynamatrixStash {
     /** Determine the path to git refrepo dir for this workspace
      *
      * @param script
-     * @return  null if {@link #useGitRefrepoDirWS} returns false,
+     * @return  null if we can not resolve {@code script.env.WORKSPACE}
+     *          or if {@link #useGitRefrepoDirWS} returns false,
      *          otherwise returns the path to git refrepo dir (currently
      *          hard-coded as {@code "${WORKSPACE}/../.gitcache-dynamatrix")
      */
     static String getGitRefrepoDirWSbase(def script) {
         // TODO: Find a way to know build agent workdir - that
         //  is what we want; "path relative to workspace" may lie
-        if (!useGitRefrepoDirWS(script)) return null
+        if (!(Utils.isStringNotEmpty(script?.env?.WORKSPACE)) || !useGitRefrepoDirWS(script)) return null
         return "${script.env.WORKSPACE}/../.gitcache-dynamatrix"
     }
 

--- a/src/org/nut/dynamatrix/DynamatrixStash.groovy
+++ b/src/org/nut/dynamatrix/DynamatrixStash.groovy
@@ -834,7 +834,9 @@ echo "[DEBUG] Files in `pwd`: `find . -type f | wc -l` and all FS objects under:
             script.echo "[DEBUG] checkoutCleanSrcRefrepoWS: node '${script?.env?.NODE_NAME}' waiting for exclusive use (${lockName}) of git cache dir to check out: repo '${scmURL}' commit '${scmCommit}'"
             script.lock (resource: lockName, quantity: 1) {
                 // NOTE: Currently this means one lock for all git ops of the CI
-                // farm. An apparent bottleneck to optimize (smartly!) later.
+                // farm per hypervisor via DYNAMATRIX_REFREPO_WORKSPACE_LOCKNAME
+                // (or overall, if we default).
+                // An apparent bottleneck to optimize (smartly!) later.
 
                 String refrepoBase = null
                 String refrepoName = null

--- a/src/org/nut/dynamatrix/DynamatrixStash.groovy
+++ b/src/org/nut/dynamatrix/DynamatrixStash.groovy
@@ -859,12 +859,12 @@ echo "[DEBUG] Files in `pwd`: `find . -type f | wc -l` and all FS objects under:
                     refrepoName = script?.env?.JOB_NAME?.replaceFirst(/\/(PR-[0-9]+|master|main|trunk)$/, '')
                 }
                 if (!refrepoName) {
-                    refrepoName = scmURL.replaceFirst(/\\.git$/, '')
+                    refrepoName = scmURL.replaceFirst(/\.git$/, '')
                     String rOld = null
                     // Chop off URL components until repo base name remains:
                     while (rOld != refrepoName) {
                         rOld = refrepoName
-                        refrepoName = refrepoName - ~/^.*\\//
+                        refrepoName = refrepoName - ~/^.*\//
                     }
                     refrepoName = refrepoName?.replaceAll(/[^A-Za-z0-9_+-]+/, /_/)
                 }

--- a/src/org/nut/dynamatrix/DynamatrixStash.groovy
+++ b/src/org/nut/dynamatrix/DynamatrixStash.groovy
@@ -81,6 +81,9 @@ class DynamatrixStash {
      */
     private static Map stashSCMVars = [:]
 
+    /** Delete directories associated with this workspace
+     *  (current directory!), including possible {@code @tmp}
+     *  and {@code @script} satellites). */
     static void deleteWS(def script) {
         /* clean up our workspace (current directory) */
         script.deleteDir()
@@ -96,10 +99,24 @@ class DynamatrixStash {
         }
     } // deleteWS()
 
+    /** Determine if we should use a git refrepo for this workspace
+     *
+     * @param script
+     * @return  true if {@link dynamatrixGlobalState#useGitRefrepoDirWS} is true,
+     *          or if {@code script.env} defines a {@code GIT_REFERENCE_REPO_DIR}
+     *          envvar with value {@code "WS"} (hack in {@link #checkoutCleanSrcRefrepoWS}.
+     */
     static Boolean useGitRefrepoDirWS(def script) {
         return (dynamatrixGlobalState?.useGitRefrepoDirWS || "WS" == script?.env?.GIT_REFERENCE_REPO_DIR)
     }
 
+    /** Determine the path to git refrepo dir for this workspace
+     *
+     * @param script
+     * @return  null if {@link #useGitRefrepoDirWS} returns false,
+     *          otherwise returns the path to git refrepo dir (currently
+     *          hard-coded as {@code "${WORKSPACE}/../.gitcache-dynamatrix")
+     */
     static String getGitRefrepoDirWSbase(def script) {
         // TODO: Find a way to know build agent workdir - that
         //  is what we want; "path relative to workspace" may lie
@@ -341,7 +358,7 @@ class DynamatrixStash {
 
     /**
      * Per https://plugins.jenkins.io/workflow-scm-step/ the common
-     * "scm" is a Map maintained by the pipeline, so we can tweak it
+     * "scm" is a Map maintained by the pipeline, so we can tweak it.
      * Per other observations, it can be e.g. a GitSCM object instead.<br/>
      *
      * In any case, use a clone to avoid manipulating options of the

--- a/src/org/nut/dynamatrix/DynamatrixStash.groovy
+++ b/src/org/nut/dynamatrix/DynamatrixStash.groovy
@@ -885,7 +885,7 @@ echo "[DEBUG] Files in `pwd`: `find . -type f | wc -l` and all FS objects under:
                     //script.withEnv(["GIT_REFERENCE_REPO_DIR="]) {
                         // check if git is there at all (error out if can't init)
                         script.sh (label:"Ensuring git workspace presence in refrepo path",
-                            script: "if [ -e .git ] || grep -qw bare config ; then true ; else git init --bare && git config gc.auto 0 || exit ; fi; test -e .git || grep -qw bare config")
+                            script: "if [ -e .git ] || grep -qw bare config ; then true ; else git init --bare && git config gc.auto 0 || exit; test -e .git || grep -qw bare config ; fi")
 
                         // check if commit is there (non-fatal)
                         // TODO: generic SCM revision check? Specific GitSCM trick?

--- a/src/org/nut/dynamatrix/DynamatrixStash.groovy
+++ b/src/org/nut/dynamatrix/DynamatrixStash.groovy
@@ -855,8 +855,8 @@ echo "[DEBUG] Files in `pwd`: `find . -type f | wc -l` and all FS objects under:
                 // May be passed by caller like dynacfgPipeline.stashnameSrc='nut-ci-src'
                 refrepoName = stashName?.replaceAll(/[^A-Za-z0-9_+-]+/, /_/)
                 if (!refrepoName) {
-                    // e.g. "nut/nut/master" or "nut/nut/PR-683" for MBR pipelines
-                    refrepoName = script?.env?.JOB_NAME?.replaceFirst(/\\/PR-[0-9]+$/, '')
+                    // e.g. "nut/nut/master" or "nut/nut/PR-683" => shared "nut/nut" for MBR pipelines
+                    refrepoName = script?.env?.JOB_NAME?.replaceFirst(/\/(PR-[0-9]+|master|main|trunk)$/, '')
                 }
                 if (!refrepoName) {
                     refrepoName = scmURL.replaceFirst(/\\.git$/, '')

--- a/src/org/nut/dynamatrix/DynamatrixStash.groovy
+++ b/src/org/nut/dynamatrix/DynamatrixStash.groovy
@@ -838,8 +838,12 @@ echo "[DEBUG] Files in `pwd`: `find . -type f | wc -l` and all FS objects under:
                 // (or overall, if we default).
                 // An apparent bottleneck to optimize (smartly!) later.
 
+                // Location under which we can have git reference repositories
                 String refrepoBase = null
+                // Possible subdirectory relative to refrepoBase,
+                // for a refrepo relevant to (re-runs of) this job
                 String refrepoName = null
+                // Ultimate `script.pwd()` inside dir(refrepoBase + '/' + refrepoName) {}
                 String refrepoPath = null
 
                 script.withEnv(["GIT_REFERENCE_REPO_DIR=WS"]) {
@@ -848,6 +852,7 @@ echo "[DEBUG] Files in `pwd`: `find . -type f | wc -l` and all FS objects under:
                     refrepoBase = getGitRefrepoDirWSbase(script)
                 } // hacky withEnv for checking/populating refrepo in a workspace
 
+                // May be passed by caller like dynacfgPipeline.stashnameSrc='nut-ci-src'
                 refrepoName = stashName?.replaceAll(/[^A-Za-z0-9_+-]+/, /_/)
                 if (!refrepoName) {
                     // e.g. "nut/nut/master" or "nut/nut/PR-683" for MBR pipelines
@@ -856,6 +861,7 @@ echo "[DEBUG] Files in `pwd`: `find . -type f | wc -l` and all FS objects under:
                 if (!refrepoName) {
                     refrepoName = scmURL.replaceFirst(/\\.git$/, '')
                     String rOld = null
+                    // Chop off URL components until repo base name remains:
                     while (rOld != refrepoName) {
                         rOld = refrepoName
                         refrepoName = refrepoName - ~/^.*\\//

--- a/vars/dynamatrixPipeline.groovy
+++ b/vars/dynamatrixPipeline.groovy
@@ -490,6 +490,7 @@ def pipelineBody(Map dynacfgBase = [:], Map dynacfgPipeline = [:]) {
                                     dynamatrix.mustAbort = false
                                 }
 
+                                dynamatrix.dynamatrixGithubNotificationContext = "slowbuild-run"
                                 dynamatrix.saveDynacfg()
                                 infra.reportGithubStageStatus(dynacfgPipeline.get("stashnameSrc"),
                                         'Discover slow build matrix',


### PR DESCRIPTION
A lengthy `deleteWS()` operation for a particular slowbuild stage happens inside `checkoutCleanSrcRefrepoWS() => checkoutCleanSrc()` while the hypervisor/controller-wide lock is taken. This can be done outside the lock and so speed up other stages that spend a lot of time waiting for the lock.

Also revise "slow" vs "quick" stage notifications, again.